### PR TITLE
Allow to use Otto with AndroidAnnotations' generated classes. 

### DIFF
--- a/library/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
+++ b/library/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
@@ -49,7 +49,10 @@ final class AnnotatedHandlerFinder {
     Map<Class<?>, Set<Method>> subscriberMethods = new HashMap<Class<?>, Set<Method>>();
     Map<Class<?>, Method> producerMethods = new HashMap<Class<?>, Method>();
 
-    for (Method method : listenerClass.getDeclaredMethods()) {
+    Class<?> superClass = listenerClass.getSuperclass(), targetClass = listenerClass;
+    if (superClass != null && listenerClass.getSimpleName().equals(superClass.getSimpleName() + "_"))
+    	targetClass = superClass;
+    for (Method method : targetClass.getDeclaredMethods()) {
       if (method.isAnnotationPresent(Subscribe.class)) {
         Class<?>[] parameterTypes = method.getParameterTypes();
         if (parameterTypes.length != 1) {


### PR DESCRIPTION
There is a problem using https://github.com/excilys/androidannotations with Otto. When we pass `this` to Otto, it can see generated by AA class, which doesn't have any `@Subscribe` and `@Produce` annotations.
The first solution is to wrap all annotated methods on ClassA_ in the AndroidAnnotations project, something like this:

```
@EActivity
class ClassActivity{
  @Subscribe public void onMyEvent(Event event){
    //...
  }
}
```

Generated class could be:

```
class ClassActivity_{
  @Subscribe public void onMyEvent_(Event event){
    onMyEvent(event);  
  }
}
```

We use wrappers for methods to call `this.onMyEvent` which could be overriden in `ClassActivity_`

But it is rather complicated to generate lots of code. The easiest way is to modify Otto a bit. We assume, that ClassA_ is generated by AA from ClassA.
