### PR TITLE
add found handlers, then dispatch produced events

### DIFF
--- a/library/src/main/java/com/squareup/otto/HandlerFinder.java
+++ b/library/src/main/java/com/squareup/otto/HandlerFinder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.otto;
+
+import java.util.Map;
+import java.util.Set;
+
+/** Finds producer and subscriber methods. */
+interface HandlerFinder {
+
+  Map<Class<?>, EventProducer> findAllProducers(Object listener);
+
+  Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener);
+
+
+  HandlerFinder ANNOTATED = new HandlerFinder() {
+    @Override
+    public Map<Class<?>, EventProducer> findAllProducers(Object listener) {
+      return AnnotatedHandlerFinder.findAllProducers(listener);
+    }
+
+    @Override
+    public Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener) {
+      return AnnotatedHandlerFinder.findAllSubscribers(listener);
+    }
+  };
+}

--- a/library/src/test/java/com/squareup/otto/UnregisteringHandlerTest.java
+++ b/library/src/test/java/com/squareup/otto/UnregisteringHandlerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.otto;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+
+import static junit.framework.Assert.assertEquals;
+
+/** Test case for subscribers which unregister while handling an event. */
+public class UnregisteringHandlerTest {
+
+  private static final String EVENT = "Hello";
+  private static final String BUS_IDENTIFIER = "test-bus";
+
+  private Bus bus;
+
+
+  @Before
+  public void setUp() throws Exception {
+    bus = new Bus(ThreadEnforcer.ANY, BUS_IDENTIFIER, new SortedHandlerFinder());
+  }
+
+
+  @Test
+  public void unregisterInHandler() {
+    UnregisteringStringCatcher catcher = new UnregisteringStringCatcher(bus);
+    bus.register(catcher);
+    bus.post(EVENT);
+
+    List<String> expectedEvents = new ArrayList<String>();
+    expectedEvents.add(EVENT);
+
+    assertEquals("One correct event should be delivered.", Arrays.asList(EVENT), catcher.getEvents());
+
+    bus.post(EVENT);
+    bus.post(EVENT);
+    assertEquals("Shouldn't catch any more events when unregistered.", expectedEvents, catcher.getEvents());
+  }
+
+  @Test public void unregisterInHandlerWhenEventProduced() throws Exception {
+    UnregisteringStringCatcher catcher = new UnregisteringStringCatcher(bus);
+
+    bus.register(new StringProducer());
+    bus.register(catcher);
+    assertEquals(Arrays.asList(StringProducer.VALUE), catcher.getEvents());
+
+    bus.post(EVENT);
+    bus.post(EVENT);
+    assertEquals("Shouldn't catch any more events when unregistered.",
+        Arrays.asList(StringProducer.VALUE), catcher.getEvents());
+  }
+
+  /** Delegates to {@code HandlerFinder.ANNOTATED}, then sorts results by {@code EventHandler#toString} */
+  static class SortedHandlerFinder implements HandlerFinder {
+
+    static Comparator<EventHandler> handlerComparator = new Comparator<EventHandler>() {
+      @Override
+      public int compare(EventHandler eventHandler, EventHandler eventHandler1) {
+        return eventHandler.toString().compareTo(eventHandler1.toString());
+      }
+    };
+
+    @Override
+    public Map<Class<?>, EventProducer> findAllProducers(Object listener) {
+      return HandlerFinder.ANNOTATED.findAllProducers(listener);
+    }
+
+    @Override
+    public Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener) {
+      Map<Class<?>, Set<EventHandler>> found = HandlerFinder.ANNOTATED.findAllSubscribers(listener);
+      Map<Class<?>, Set<EventHandler>> sorted = new HashMap<Class<?>, Set<EventHandler>>();
+      for (Map.Entry<Class<?>, Set<EventHandler>> entry : found.entrySet()) {
+        SortedSet<EventHandler> handlers = new TreeSet<EventHandler>(handlerComparator);
+        handlers.addAll(entry.getValue());
+        sorted.put(entry.getKey(), handlers);
+      }
+      return sorted;
+    }
+  }
+}

--- a/library/src/test/java/com/squareup/otto/UnregisteringStringCatcher.java
+++ b/library/src/test/java/com/squareup/otto/UnregisteringStringCatcher.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.otto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** An EventHandler mock that records a String and unregisters itself in the handler. */
+public class UnregisteringStringCatcher {
+  private final Bus bus;
+
+  private List<String> events = new ArrayList<String>();
+
+  public UnregisteringStringCatcher(Bus bus) {
+    this.bus = bus;
+  }
+
+  @Subscribe public void unregisterOnString(String event) {
+    bus.unregister(this);
+    events.add(event);
+  }
+
+  @Subscribe public void haveAnInteger(Integer event) {}
+
+  @Subscribe public void enjoyThisLong(Long event) {}
+
+  @Subscribe public void perhapsATastyDouble(Double event) {}
+
+  public List<String> getEvents() {
+    return events;
+  }
+}


### PR DESCRIPTION
Do this in two passes rather than one to avoid an IllegalArgumentException
when a handler attempts to unregister from the bus.
