### PR TITLE
Objects never produce or handle once unregistered.

### DIFF
--- a/library/src/main/java/com/squareup/otto/Bus.java
+++ b/library/src/main/java/com/squareup/otto/Bus.java
@@ -216,18 +216,17 @@ public class Bus {
       handlers.addAll(foundHandlers);
     }
 
-
     for (Map.Entry<Class<?>, Set<EventHandler>> entry : foundHandlersMap.entrySet()) {
       Class<?> type = entry.getKey();
       EventProducer producer = producersByType.get(type);
-      if (producer != null) {
-        Set<EventHandler> currentHandlers = getHandlersForEventType(type);
-        if (currentHandlers != null) {
-          Set<EventHandler> foundHandlers = entry.getValue();
-          for (EventHandler foundHandler : foundHandlers) {
-            if (currentHandlers.contains(foundHandler)) {
-              dispatchProducerResultToHandler(foundHandler, producer);
-            }
+      if (producer != null && producer.isValid()) {
+        Set<EventHandler> foundHandlers = entry.getValue();
+        for (EventHandler foundHandler : foundHandlers) {
+          if (!producer.isValid()) {
+            break;
+          }
+          if (foundHandler.isValid()) {
+            dispatchProducerResultToHandler(foundHandler, producer);
           }
         }
       }
@@ -244,13 +243,7 @@ public class Bus {
     if (event == null) {
       return;
     }
-    try {
-      handler.handleEvent(event);
-    } catch (InvocationTargetException e) {
-      String type = event.getClass().toString();
-      throw new RuntimeException(
-          "Could not dispatch event " + type + " from " + producer + " to handler " + handler, e);
-    }
+    dispatch(event, handler);
   }
 
   /**
@@ -273,7 +266,7 @@ public class Bus {
             "Missing event producer for an annotated method. Is " + object.getClass()
                 + " registered?");
       }
-      producersByType.remove(key);
+      producersByType.remove(key).invalidate();
     }
 
     Map<Class<?>, Set<EventHandler>> handlersInListener = handlerFinder.findAllSubscribers(object);
@@ -281,11 +274,18 @@ public class Bus {
       Set<EventHandler> currentHandlers = getHandlersForEventType(entry.getKey());
       Collection<EventHandler> eventMethodsInListener = entry.getValue();
 
-      if (currentHandlers == null || !currentHandlers.removeAll(eventMethodsInListener)) {
+      if (currentHandlers == null || !currentHandlers.containsAll(eventMethodsInListener)) {
         throw new IllegalArgumentException(
             "Missing event handler for an annotated method. Is " + object.getClass()
                 + " registered?");
       }
+
+      for (EventHandler handler : currentHandlers) {
+        if (eventMethodsInListener.contains(handler)) {
+          handler.invalidate();
+        }
+      }
+      currentHandlers.removeAll(eventMethodsInListener);
     }
   }
 
@@ -349,7 +349,9 @@ public class Bus {
           break;
         }
 
-        dispatch(eventWithHandler.event, eventWithHandler.handler);
+        if (eventWithHandler.handler.isValid()) {
+          dispatch(eventWithHandler.event, eventWithHandler.handler);
+        }
       }
     } finally {
       isDispatching.set(false);

--- a/library/src/main/java/com/squareup/otto/EventHandler.java
+++ b/library/src/main/java/com/squareup/otto/EventHandler.java
@@ -39,6 +39,8 @@ class EventHandler {
   private final Method method;
   /** Object hash code. */
   private final int hashCode;
+  /** Should this handler receive events? */
+  private boolean valid = true;
 
   EventHandler(Object target, Method method) {
     if (target == null) {
@@ -58,14 +60,31 @@ class EventHandler {
     hashCode = (prime + method.hashCode()) * prime + target.hashCode();
   }
 
+  public boolean isValid() {
+    return valid;
+  }
+
+  /**
+   * If invalidated, will subsequently refuse to handle events.
+   *
+   * Should be called when the wrapped object is unregistered from the Bus.
+   */
+  public void invalidate() {
+    valid = false;
+  }
+
   /**
    * Invokes the wrapped handler method to handle {@code event}.
    *
    * @param event  event to handle
+   * @Throws java.lang.IllegalStateException  if previously invalidated.
    * @throws java.lang.reflect.InvocationTargetException  if the wrapped method throws any {@link Throwable} that is not
    *     an {@link Error} ({@code Error}s are propagated as-is).
    */
   public void handleEvent(Object event) throws InvocationTargetException {
+    if (!valid) {
+      throw new IllegalStateException(toString() + " has been invalidated and can no longer handle events.");
+    }
     try {
       method.invoke(target, new Object[] {event});
     } catch (IllegalAccessException e) {

--- a/library/src/test/java/com/squareup/otto/UnregisteringStringCatcher.java
+++ b/library/src/test/java/com/squareup/otto/UnregisteringStringCatcher.java
@@ -34,6 +34,10 @@ public class UnregisteringStringCatcher {
     events.add(event);
   }
 
+  @Subscribe public void zzzSleepinOnStrings(String event) {
+    events.add(event);
+  }
+
   @Subscribe public void haveAnInteger(Integer event) {}
 
   @Subscribe public void enjoyThisLong(Long event) {}


### PR DESCRIPTION
This is a more general and complete fix than the previous change, at the cost
of a more expensive unregister() implementation.
