### PR TITLE
move ThreadEnforcer implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ Change Log
 Version 1.4.0 *(In Development)*
 --------------------------------
 
- * Introduce `ThreadEnforcer.NONE` which does no validation. Deprecate
-   `ThreadEnforcer.ANY` which will be removed in the next minor version.
-
-
+ * Introduce `ThreadEnforcers.NONE` which does no validation. Move
+   `ThreadEnforcer.MAIN to `ThreadEnforcers.MAIN`. Deprecate
+   `ThreadEnforcer.ANY` and `ThreadEnforcer.MAIN`, which will be removed in
+   the next minor version.
+ 
 Version 1.3.2 *(2012-10-16)*
 ----------------------------
 

--- a/library/src/main/java/com/squareup/otto/Bus.java
+++ b/library/src/main/java/com/squareup/otto/Bus.java
@@ -131,7 +131,7 @@ public class Bus {
    * @param identifier a brief name for this bus, for debugging purposes.  Should be a valid Java identifier.
    */
   public Bus(String identifier) {
-    this(ThreadEnforcer.MAIN, identifier);
+    this(ThreadEnforcers.MAIN, identifier);
   }
 
   /**

--- a/library/src/main/java/com/squareup/otto/ThreadEnforcer.java
+++ b/library/src/main/java/com/squareup/otto/ThreadEnforcer.java
@@ -33,17 +33,10 @@ public interface ThreadEnforcer {
   void enforce(Bus bus);
 
 
-  /** A {@link ThreadEnforcer} that does no verification or enforcement for any action. */
-  ThreadEnforcer NONE = new ThreadEnforcer() {
-    @Override public void enforce(Bus bus) {
-      // Allow any thread.
-    }
-  };
+  /** @deprecated Use {@link ThreadEnforcers#NONE}. */
+  @Deprecated ThreadEnforcer ANY = ThreadEnforcers.NONE;
 
-  /** @deprecated Use {@link #NONE}. */
-  @Deprecated ThreadEnforcer ANY = NONE;
-
-  /** A {@link ThreadEnforcer} that confines {@link Bus} methods to the main thread. */
+  /** @deprecated Use {@link ThreadEnforcers#MAIN}. */
   ThreadEnforcer MAIN = new ThreadEnforcer() {
     @Override public void enforce(Bus bus) {
       if (Looper.myLooper() != Looper.getMainLooper()) {

--- a/library/src/main/java/com/squareup/otto/ThreadEnforcers.java
+++ b/library/src/main/java/com/squareup/otto/ThreadEnforcers.java
@@ -1,0 +1,26 @@
+package com.squareup.otto;
+
+import android.os.Looper;
+
+public abstract class ThreadEnforcers {
+
+  private ThreadEnforcers() {
+  }
+
+  /** A {@link com.squareup.otto.ThreadEnforcer} that does no verification or enforcement for any action. */
+  public static final ThreadEnforcer NONE = new ThreadEnforcer() {
+    @Override public void enforce(Bus bus) {
+      // Allow any thread.
+    }
+  };
+
+  /** A {@link ThreadEnforcer} that confines {@link Bus} methods to the main thread. */
+  public static final ThreadEnforcer MAIN = new ThreadEnforcer() {
+    @Override public void enforce(Bus bus) {
+      if (Looper.myLooper() != Looper.getMainLooper()) {
+        throw new IllegalStateException("Event bus " + bus + " accessed from non-main thread " + Looper.myLooper());
+      }
+    }
+  };
+
+}

--- a/library/src/test/java/com/squareup/otto/BusTest.java
+++ b/library/src/test/java/com/squareup/otto/BusTest.java
@@ -42,7 +42,7 @@ public class BusTest {
   private Bus bus;
 
   @Before public void setUp() throws Exception {
-    bus = new Bus(ThreadEnforcer.NONE, BUS_IDENTIFIER);
+    bus = new Bus(ThreadEnforcers.NONE, BUS_IDENTIFIER);
   }
 
   @Test public void basicCatcherDistribution() {

--- a/library/src/test/java/com/squareup/otto/EventBusInnerClassStressTest.java
+++ b/library/src/test/java/com/squareup/otto/EventBusInnerClassStressTest.java
@@ -25,7 +25,7 @@ public class EventBusInnerClassStressTest {
   Sub sub = new Sub();
 
   @Test public void eventBusOkayWithNonStaticInnerClass() {
-    Bus eb = new Bus(ThreadEnforcer.NONE);
+    Bus eb = new Bus(ThreadEnforcers.NONE);
     eb.register(sub);
     int i = 0;
     while (i < REPS) {
@@ -37,7 +37,7 @@ public class EventBusInnerClassStressTest {
   }
 
   @Test public void eventBusFailWithAnonInnerClass() {
-    Bus eb = new Bus(ThreadEnforcer.NONE);
+    Bus eb = new Bus(ThreadEnforcers.NONE);
     eb.register(new Object() {
       @Subscribe
       public void in(String o) {
@@ -54,7 +54,7 @@ public class EventBusInnerClassStressTest {
   }
 
   @Test public void eventBusNpeWithAnonInnerClassWaitingForObject() {
-    Bus eb = new Bus(ThreadEnforcer.NONE);
+    Bus eb = new Bus(ThreadEnforcers.NONE);
     eb.register(new Object() {
       @Subscribe
       public void in(Object o) {

--- a/library/src/test/java/com/squareup/otto/ReentrantEventsTest.java
+++ b/library/src/test/java/com/squareup/otto/ReentrantEventsTest.java
@@ -36,7 +36,7 @@ public class ReentrantEventsTest {
   static final String FIRST = "one";
   static final Double SECOND = 2.0d;
 
-  final Bus bus = new Bus(ThreadEnforcer.NONE);
+  final Bus bus = new Bus(ThreadEnforcers.NONE);
 
   @Test public void noReentrantEvents() {
     ReentrantEventsHater hater = new ReentrantEventsHater();

--- a/library/src/test/java/com/squareup/otto/UnregisteringHandlerTest.java
+++ b/library/src/test/java/com/squareup/otto/UnregisteringHandlerTest.java
@@ -34,7 +34,7 @@ public class UnregisteringHandlerTest {
 
   @Before
   public void setUp() throws Exception {
-    bus = new Bus(ThreadEnforcer.NONE, BUS_IDENTIFIER, new SortedHandlerFinder());
+    bus = new Bus(ThreadEnforcers.NONE, BUS_IDENTIFIER, new SortedHandlerFinder());
   }
 
 

--- a/library/src/test/java/com/squareup/otto/outside/AnnotatedHandlerFinderTest.java
+++ b/library/src/test/java/com/squareup/otto/outside/AnnotatedHandlerFinderTest.java
@@ -18,7 +18,7 @@ package com.squareup.otto.outside;
 
 import com.squareup.otto.Bus;
 import com.squareup.otto.Subscribe;
-import com.squareup.otto.ThreadEnforcer;
+import com.squareup.otto.ThreadEnforcers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -58,7 +58,7 @@ public class AnnotatedHandlerFinderTest {
     @Before
     public void setUp() throws Exception {
       handler = createHandler();
-      Bus bus = new Bus(ThreadEnforcer.NONE);
+      Bus bus = new Bus(ThreadEnforcers.NONE);
       bus.register(handler);
       bus.post(EVENT);
     }
@@ -196,7 +196,7 @@ public class AnnotatedHandlerFinderTest {
 
     @Test public void subscribingToInterfacesFails() {
       try {
-        new Bus(ThreadEnforcer.NONE).register(new InterfaceSubscriber());
+        new Bus(ThreadEnforcers.NONE).register(new InterfaceSubscriber());
         fail("Annotation finder allowed subscription to illegal interface type.");
       } catch (IllegalArgumentException expected) {
         // Do nothing.

--- a/library/src/test/java/com/squareup/otto/outside/AnnotatedProducerFinderTest.java
+++ b/library/src/test/java/com/squareup/otto/outside/AnnotatedProducerFinderTest.java
@@ -19,7 +19,7 @@ package com.squareup.otto.outside;
 import com.squareup.otto.Bus;
 import com.squareup.otto.Produce;
 import com.squareup.otto.Subscribe;
-import com.squareup.otto.ThreadEnforcer;
+import com.squareup.otto.ThreadEnforcers;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -59,7 +59,7 @@ public class AnnotatedProducerFinderTest {
   }
 
   @Test public void simpleProducer() {
-    Bus bus = new Bus(ThreadEnforcer.NONE);
+    Bus bus = new Bus(ThreadEnforcers.NONE);
     Subscriber subscriber = new Subscriber();
     SimpleProducer producer = new SimpleProducer();
 
@@ -71,7 +71,7 @@ public class AnnotatedProducerFinderTest {
   }
 
   @Test public void multipleSubscriptionsCallsProviderEachTime() {
-    Bus bus = new Bus(ThreadEnforcer.NONE);
+    Bus bus = new Bus(ThreadEnforcers.NONE);
     SimpleProducer producer = new SimpleProducer();
 
     bus.register(producer);

--- a/library/src/test/java/com/squareup/otto/outside/OutsideEventBusTest.java
+++ b/library/src/test/java/com/squareup/otto/outside/OutsideEventBusTest.java
@@ -18,7 +18,7 @@ package com.squareup.otto.outside;
 
 import com.squareup.otto.Bus;
 import com.squareup.otto.Subscribe;
-import com.squareup.otto.ThreadEnforcer;
+import com.squareup.otto.ThreadEnforcers;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -41,7 +41,7 @@ public class OutsideEventBusTest {
   @Test public void anonymous() {
     final AtomicReference<String> holder = new AtomicReference<String>();
     final AtomicInteger deliveries = new AtomicInteger();
-    Bus bus = new Bus(ThreadEnforcer.NONE);
+    Bus bus = new Bus(ThreadEnforcers.NONE);
     bus.register(new Object() {
       @Subscribe
       public void accept(String str) {

--- a/website/index.html
+++ b/website/index.html
@@ -89,9 +89,9 @@
             with an instance is confined to the main thread.</p>
             <pre class="prettyprint">// Both of these are functionally equivalent.
 Bus bus1 = new Bus();
-Bus bus2 = new Bus(ThreadEnforcer.MAIN);</pre>
+Bus bus2 = new Bus(ThreadEnforcers.MAIN);</pre>
             <p>If you are not concerned on which thread interaction is occurring, instantiate a bus instance with
-            <code>ThreadEnforcer.ANY</code>. You can also provide your own implementation of the
+            <code>ThreadEnforcers.NONE</code>. You can also provide your own implementation of the
             <code>ThreadEnforcer</code> interface if you need additional functionality or validation.</p>
 
             <h4>Including In Your Application</h4>


### PR DESCRIPTION
Having the implementations on an abstract class rather than the interface
gives us room to grow by adding factory methods for new enforcers which need
parameters.
