### PR TITLE
remove module DoubleCheckedLocking (no longer supported as of Checkstyle...

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -88,7 +88,6 @@
         <!-- See http://checkstyle.sf.net/config_coding.html -->
         <!--module name="AvoidInlineConditionals"/-->
         <module name="CovariantEquals"/>
-        <module name="DoubleCheckedLocking"/>
         <module name="EmptyStatement"/>
         <module name="EqualsAvoidNull"/>
         <module name="EqualsHashCode"/>


### PR DESCRIPTION
... 5.6).  See http://checkstyle.sourceforge.net/releasenotes.html.  
