### PR TITLE
add base interface OttoBus, have Bus implement it.

### DIFF
--- a/library/src/main/java/com/squareup/otto/Bus.java
+++ b/library/src/main/java/com/squareup/otto/Bus.java
@@ -85,7 +85,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
  * @author Cliff Biffle
  * @author Jake Wharton
  */
-public class Bus {
+public class Bus implements OttoBus {
   public static final String DEFAULT_IDENTIFIER = "default";
 
   /** All registered event handlers, indexed by event type. */
@@ -181,6 +181,7 @@ public class Bus {
    *
    * @param object object whose handler methods should be registered.
    */
+  @Override
   public void register(Object object) {
     enforcer.enforce(this);
 
@@ -252,6 +253,7 @@ public class Bus {
    * @param object object whose producer and handler methods should be unregistered.
    * @throws IllegalArgumentException if the object was not previously registered.
    */
+  @Override
   public void unregister(Object object) {
     enforcer.enforce(this);
 
@@ -298,6 +300,7 @@ public class Bus {
    *
    * @param event event to post.
    */
+  @Override
   public void post(Object event) {
     enforcer.enforce(this);
 

--- a/library/src/main/java/com/squareup/otto/OttoBus.java
+++ b/library/src/main/java/com/squareup/otto/OttoBus.java
@@ -1,0 +1,7 @@
+package com.squareup.otto;
+
+public interface OttoBus {
+    void register(Object object);
+    void unregister(Object object);
+    void post(Object event);
+}

--- a/library/src/main/java/com/squareup/otto/ThreadEnforcer.java
+++ b/library/src/main/java/com/squareup/otto/ThreadEnforcer.java
@@ -30,19 +30,19 @@ public interface ThreadEnforcer {
    *
    * @param bus Event bus instance on which an action is being performed.
    */
-  void enforce(Bus bus);
+  void enforce(OttoBus bus);
 
 
   /** A {@link ThreadEnforcer} that does no verification or enforcement for any action. */
   ThreadEnforcer NONE = new ThreadEnforcer() {
-    @Override public void enforce(Bus bus) {
+    @Override public void enforce(OttoBus bus) {
       // Allow any thread.
     }
   };
 
   /** A {@link ThreadEnforcer} that confines {@link Bus} methods to the main thread. */
   ThreadEnforcer MAIN = new ThreadEnforcer() {
-    @Override public void enforce(Bus bus) {
+    @Override public void enforce(OttoBus bus) {
       if (Looper.myLooper() != Looper.getMainLooper()) {
         throw new IllegalStateException("Event bus " + bus + " accessed from non-main thread " + Looper.myLooper());
       }

--- a/library/src/test/java/com/squareup/otto/ThreadEnforcerTest.java
+++ b/library/src/test/java/com/squareup/otto/ThreadEnforcerTest.java
@@ -26,7 +26,7 @@ public class ThreadEnforcerTest {
   private static class RecordingThreadEnforcer implements ThreadEnforcer {
     boolean called = false;
 
-    @Override public void enforce(Bus bus) {
+    @Override public void enforce(OttoBus bus) {
       called = true;
     }
   }


### PR DESCRIPTION
Creating a base interface allows instances of classes that act like a Bus but aren't a Bus (e.g. ScopedBus) to be passed around as a standard interface.  To minimize disruption to existing code, I left the name of the Bus class alone and named the interface OttoBus.
