### PR TITLE
add base interface OttoBus, have Bus implement it.

### DIFF
--- a/library/src/main/java/com/squareup/otto/Bus.java
+++ b/library/src/main/java/com/squareup/otto/Bus.java
@@ -32,60 +32,18 @@ import static com.squareup.otto.internal.AnnotationProcessor.FINDER_SUFFIX;
 import static com.squareup.otto.internal.AnnotationProcessor.PACKAGE_PREFIX;
 
 /**
- * Dispatches events to listeners, and provides ways for listeners to register themselves.
+ * The reference implementation for the OttoBus interface.  Dispatches events to listeners, and provides ways for
+ * listeners to register themselves.
  *
- * <p>The Bus allows publish-subscribe-style communication between components without requiring the components to
- * explicitly register with one another (and thus be aware of each other).  It is designed exclusively to replace
- * traditional Android in-process event distribution using explicit registration or listeners. It is <em>not</em> a
- * general-purpose publish-subscribe system, nor is it intended for interprocess communication.
- *
- * <h2>Receiving Events</h2>
- * To receive events, an object should:
- * <ol>
- * <li>Expose a public method, known as the <i>event subscriber</i>, which accepts a single argument of the type of
- * event desired;</li>
- * <li>Mark it with a {@link com.squareup.otto.Subscribe} annotation;</li>
- * <li>Pass itself to an Bus instance's {@link #register(Object)} method.
- * </li>
- * </ol>
- *
- * <h2>Posting Events</h2>
- * To post an event, simply provide the event object to the {@link #post(Object)} method.  The Bus instance will
- * determine the type of event and route it to all registered listeners.
- *
- * <p>Events are routed based on their type &mdash; an event will be delivered to any subscriber for any type to which
- * the event is <em>assignable.</em>  This includes implemented interfaces, all superclasses, and all interfaces
- * implemented by superclasses.
- *
- * <p>When {@code post} is called, all registered handlers for an event are run in sequence, so handlers should be
- * reasonably quick.  If an event may trigger an extended process (such as a database load), spawn a thread or queue it
- * for later.
- *
- * <h2>Subscriber Methods</h2>
- * Event subscriber methods must accept only one argument: the event.
- *
- * <p>Handlers should not, in general, throw.  If they do, the Bus will wrap the exception and
- * re-throw it.
- *
- * <p>The Bus by default enforces that all interactions occur on the main thread.  You can provide an alternate
+ * <p>Bus, by default, enforces that all interactions occur on the main thread.  You can provide an alternate
  * enforcement by passing a {@link ThreadEnforcer} to the constructor.
- *
- * <h2>Producer Methods</h2>
- * Producer methods should accept no arguments and return their event type. When a subscriber is registered for a type
- * that a producer is also already registered for, the subscriber will be called with the return value from the
- * producer.
- *
- * <h2>Dead Events</h2>
- * If an event is posted, but no registered handlers can accept it, it is considered "dead."  To give the system a
- * second chance to handle dead events, they are wrapped in an instance of {@link com.squareup.otto.DeadEvent} and
- * reposted.
  *
  * <p>This class is safe for concurrent use.
  *
  * @author Cliff Biffle
  * @author Jake Wharton
  */
-public class Bus {
+public class Bus implements OttoBus{
   public static final String DEFAULT_IDENTIFIER = "default";
 
   /** All registered event handlers, indexed by event type. */
@@ -186,18 +144,7 @@ public class Bus {
     return fallbackFinder;
   }
 
-  /**
-   * Registers all subscriber methods on {@code object} to receive events and producer methods to provide events.
-   * <p>
-   * If any subscribers are registering for types which already have a producer they will be called immediately
-   * with the result of calling that producer.
-   * <p>
-   * If any producers are registering for types which already have subscribers, each subscriber will be called with
-   * the value from the result of calling the producer.
-   *
-   * @param object object whose subscriber methods should be registered.
-   */
-  public void register(Object object) {
+  @Override public void register(Object object) {
     enforcer.enforce(this);
     obtainFinder(object.getClass()).install(object, this);
   }
@@ -221,13 +168,7 @@ public class Bus {
     }
   }
 
-  /**
-   * Unregisters all producer and subscriber methods on a registered {@code object}.
-   *
-   * @param object object whose producer and subscriber methods should be unregistered.
-   * @throws IllegalArgumentException if the object was not previously registered.
-   */
-  public void unregister(Object object) {
+  @Override public void unregister(Object object) {
     enforcer.enforce(this);
     obtainFinder(object.getClass()).uninstall(object, this);
   }
@@ -274,16 +215,7 @@ public class Bus {
     }
   }
 
-  /**
-   * Posts an event to all registered handlers.  This method will return successfully after the event has been posted to
-   * all handlers, and regardless of any exceptions thrown by handlers.
-   *
-   * <p>If no handlers have been subscribed for {@code event}'s class, and {@code event} is not already a
-   * {@link DeadEvent}, it will be wrapped in a DeadEvent and reposted.
-   *
-   * @param event event to post.
-   */
-  public void post(Object event) {
+  @Override public void post(Object event) {
     enforcer.enforce(this);
 
     Set<Class<?>> dispatchTypes = flattenHierarchy(event.getClass());

--- a/library/src/main/java/com/squareup/otto/OttoBus.java
+++ b/library/src/main/java/com/squareup/otto/OttoBus.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.otto;
+
+/**
+ * Interface for event bus implementations, which dispatch events to listeners and provide ways for listeners to
+ * register themselves.
+ *
+ * <p>A class implementing this interface (henceforth, a "bus") allows publish-subscribe-style communication between
+ * components without requiring the components to explicitly register with one another (and thus be aware of each
+ * other).  This is designed exclusively to replace traditional Android in-process event distribution using explicit
+ * registration or listeners. It is <em>not</em> a general-purpose publish-subscribe system, nor is it intended for
+ * interprocess communication.
+ *
+ * <h2>Receiving Events</h2>
+ * To receive events, an object should:
+ * <ol>
+ * <li>Expose a public method, known as the <i>event handler</i>, which accepts a single argument of the type of event
+ * desired;</li>
+ * <li>Mark it with a {@link com.squareup.otto.Subscribe} annotation;</li>
+ * <li>Pass itself to the bus' {@link #register(Object)} method.
+ * </li>
+ * </ol>
+ *
+ * <h2>Posting Events</h2>
+ * To post an event, simply provide the event object to the bus' {@link #post(Object)} method.  The bus will
+ * determine the type of event and route it to all registered listeners.
+ *
+ * <p>Events are routed based on their type &mdash; an event will be delivered to any handler for any type to which the
+ * event is <em>assignable.</em>  This includes implemented interfaces, all superclasses, and all interfaces implemented
+ * by superclasses.
+ *
+ * <p>When {@code post} is called, all registered handlers for an event are run in sequence, so handlers should be
+ * reasonably quick.  If an event may trigger an extended process (such as a database load), spawn a thread or queue it
+ * for later.
+ *
+ * <h2>Handler Methods</h2>
+ * Event handler methods must accept only one argument: the event.
+ *
+ * <p>Handlers should not, in general, throw.  If they do, the bus will wrap the exception and
+ * re-throw it.
+ *
+ * <h2>Producer Methods</h2>
+ * Producer methods should accept no arguments and return their event type. When a subscriber is registered for a type
+ * that a producer is also already registered for, the subscriber will be called with the return value from the
+ * producer, provided it is not null.
+ *
+ * <h2>Dead Events</h2>
+ * If an event is posted, but no registered handlers can accept it, it is considered "dead."  To give the system a
+ * second chance to handle dead events, they are wrapped in an instance of {@link com.squareup.otto.DeadEvent} and
+ * reposted.
+ *
+ * @author Cliff Biffle
+ * @author Jake Wharton
+ */
+public interface OttoBus {
+    /**
+     * Registers all handler methods on {@code object} to receive events and producer methods to provide events.
+     * <p>
+     * If any subscribers are registering for types which already have a producer they will be called immediately
+     * with the result of calling that producer, unless the result is null.
+     * <p>
+     * If any producers are registering for types which already have subscribers, each subscriber will be called with
+     * the value from the result of calling the producer, unless the result is null.
+     *
+     * @param object object whose handler methods should be registered.
+     */
+    void register(Object object);
+
+    /**
+     * Unregisters all producer and handler methods on a registered {@code object}.
+     *
+     * @param object object whose producer and handler methods should be unregistered.
+     * @throws IllegalArgumentException if the object was not previously registered.
+     */
+    void unregister(Object object);
+
+    /**
+     * Posts an event to all registered handlers.  This method will return successfully after the event has been posted to
+     * all handlers, and regardless of any exceptions thrown by handlers.
+     *
+     * <p>If no handlers have been subscribed for {@code event}'s class, and {@code event} is not already a
+     * {@link DeadEvent}, it will be wrapped in a DeadEvent and reposted.
+     *
+     * @param event event to post.
+     */
+    void post(Object event);
+}

--- a/library/src/main/java/com/squareup/otto/ThreadEnforcer.java
+++ b/library/src/main/java/com/squareup/otto/ThreadEnforcer.java
@@ -30,19 +30,19 @@ public interface ThreadEnforcer {
    *
    * @param bus Event bus instance on which an action is being performed.
    */
-  void enforce(Bus bus);
+  void enforce(OttoBus bus);
 
 
   /** A {@link ThreadEnforcer} that does no verification or enforcement for any action. */
   ThreadEnforcer NONE = new ThreadEnforcer() {
-    @Override public void enforce(Bus bus) {
+    @Override public void enforce(OttoBus bus) {
       // Allow any thread.
     }
   };
 
   /** A {@link ThreadEnforcer} that confines {@link Bus} methods to the main thread. */
   ThreadEnforcer MAIN = new ThreadEnforcer() {
-    @Override public void enforce(Bus bus) {
+    @Override public void enforce(OttoBus bus) {
       if (Looper.myLooper() != Looper.getMainLooper()) {
         throw new IllegalStateException("Event bus " + bus + " accessed from non-main thread " + Looper.myLooper());
       }

--- a/library/src/test/java/com/squareup/otto/ThreadEnforcerTest.java
+++ b/library/src/test/java/com/squareup/otto/ThreadEnforcerTest.java
@@ -27,7 +27,7 @@ public class ThreadEnforcerTest {
   private static class RecordingThreadEnforcer implements ThreadEnforcer {
     boolean called = false;
 
-    @Override public void enforce(Bus bus) {
+    @Override public void enforce(OttoBus bus) {
       called = true;
     }
   }


### PR DESCRIPTION
Creating a base interface allows instances of classes that act like a Bus but aren't a Bus (e.g. ScopedBus) to be passed around as a standard interface. To minimize disruption to existing code, I left the name of the Bus class alone and named the interface OttoBus.  I migrated much of the javadoc content from Bus to OttoBus, with some minor editing to account for the difference between interface and implementation.  

Note: some of the junit tests are failing, but as far as I can tell, they are the same ones that were already failing in code-gen as a result of the WIP at the tip.
