### PR TITLE
Fix inconsistencies in javadocs.

### DIFF
--- a/library/src/main/java/com/squareup/otto/Bus.java
+++ b/library/src/main/java/com/squareup/otto/Bus.java
@@ -54,7 +54,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
  * determine the type of event and route it to all registered listeners.
  *
  * <p>Events are routed based on their type &mdash; an event will be delivered to any handler for any type to which the
- * event is <em>assignable.</em>  This includes implemented interfaces, all superclasses, and all interfaces implemented
+ * event is <em>assignable.</em> This includes implemented interfaces, all superclasses, and all interfaces implemented
  * by superclasses.
  *
  * <p>When {@code post} is called, all registered handlers for an event are run in sequence, so handlers should be
@@ -172,11 +172,11 @@ public class Bus {
 
   /**
    * Registers all handler methods on {@code object} to receive events and producer methods to provide events.
-   * <p>
-   * If any subscribers are registering for types which already have a producer they will be called immediately
+   *
+   * <p>If any subscribers are registering for types which already have a producer they will be called immediately
    * with the result of calling that producer.
-   * <p>
-   * If any producers are registering for types which already have subscribers, each subscriber will be called with
+   *
+   * <p>If any producers are registering for types which already have subscribers, each subscriber will be called with
    * the value from the result of calling the producer.
    *
    * @param object object whose handler methods should be registered.

--- a/library/src/main/java/com/squareup/otto/EventHandler.java
+++ b/library/src/main/java/com/squareup/otto/EventHandler.java
@@ -67,7 +67,7 @@ class EventHandler {
   /**
    * If invalidated, will subsequently refuse to handle events.
    *
-   * Should be called when the wrapped object is unregistered from the Bus.
+   * <p>Should be called when the wrapped object is unregistered from the Bus.
    */
   public void invalidate() {
     valid = false;

--- a/library/src/main/java/com/squareup/otto/EventProducer.java
+++ b/library/src/main/java/com/squareup/otto/EventProducer.java
@@ -22,7 +22,7 @@ import java.lang.reflect.Method;
 /**
  * Wraps a 'producer' method on a specific object.
  *
- * <p> This class only verifies the suitability of the method and event type if something fails.  Callers are expected
+ * <p>This class only verifies the suitability of the method and event type if something fails.  Callers are expected
  * to verify their uses of this class.
  *
  * @author Jake Wharton
@@ -63,7 +63,7 @@ class EventProducer {
   /**
    * If invalidated, will subsequently refuse to produce events.
    *
-   * Should be called when the wrapped object is unregistered from the Bus.
+   * <p>Should be called when the wrapped object is unregistered from the Bus.
    */
   public void invalidate() {
     valid = false;

--- a/library/src/main/java/com/squareup/otto/Produce.java
+++ b/library/src/main/java/com/squareup/otto/Produce.java
@@ -23,8 +23,8 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a method as an instance producer, as used by {@link AnnotatedHandlerFinder} and {@link Bus}.
- * <p>
- * Otto infers the instance type from the annotated method's return type. Producer methods may return null when there is
+ * 
+ * <p>Otto infers the instance type from the annotated method's return type. Producer methods may return null when there is
  * no appropriate value to share. The calling {@link Bus} ignores such returns and posts nothing.
  *
  * @author Jake Wharton

--- a/library/src/main/java/com/squareup/otto/Subscribe.java
+++ b/library/src/main/java/com/squareup/otto/Subscribe.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Target;
  * Marks a method as an event handler, as used by {@link AnnotatedHandlerFinder} and {@link Bus}.
  *
  * <p>The method's first (and only) parameter defines the event type.
+ *
  * <p>If this annotation is applied to methods with zero parameters or more than one parameter, the object containing
  * the method will not be able to register for event delivery from the {@link Bus}. Otto fails fast by throwing
  * runtime exceptions in these cases.

--- a/library/src/test/java/com/squareup/otto/BusTest.java
+++ b/library/src/test/java/com/squareup/otto/BusTest.java
@@ -64,7 +64,7 @@ public class BusTest {
    * Tests that events are distributed to any subscribers to their type or any
    * supertype, including interfaces and superclasses.
    *
-   * Also checks delivery ordering in such cases.
+   * <p>Also checks delivery ordering in such cases.
    */
   @Test public void polymorphicDistribution() {
     // Three catchers for related types String, Object, and Comparable<?>.

--- a/library/src/test/java/com/squareup/otto/StringCatcher.java
+++ b/library/src/test/java/com/squareup/otto/StringCatcher.java
@@ -23,7 +23,7 @@ import junit.framework.Assert;
 /**
  * A simple EventHandler mock that records Strings.
  *
- * For testing fun, also includes a landmine method that Bus tests are
+ * <p>For testing fun, also includes a landmine method that Bus tests are
  * required <em>not</em> to call ({@link #methodWithoutAnnotation(String)}).
  *
  * @author Cliff Biffle

--- a/library/src/test/java/com/squareup/otto/outside/AnnotatedHandlerFinderTest.java
+++ b/library/src/test/java/com/squareup/otto/outside/AnnotatedHandlerFinderTest.java
@@ -37,7 +37,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 /**
  * Test that Bus finds the correct handlers.
  *
- * This test must be outside the c.g.c.eventbus package to test correctly.
+ * <p>This test must be outside the c.g.c.eventbus package to test correctly.
  *
  * @author Louis Wasserman
  */

--- a/library/src/test/java/com/squareup/otto/outside/AnnotatedProducerFinderTest.java
+++ b/library/src/test/java/com/squareup/otto/outside/AnnotatedProducerFinderTest.java
@@ -32,7 +32,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 /**
  * Test that Bus finds the correct producers.
  *
- * This test must be outside the c.g.c.eventbus package to test correctly.
+ * <p>This test must be outside the c.g.c.eventbus package to test correctly.
  *
  * @author Jake Wharton
  */


### PR DESCRIPTION
These changes were made with consistency in mind, in relation to the rest of the project:
- Every new paragraph now begins with a <p> tag.
- <p> tags no longer have whitespace immediately after them.
- <p> tags are now on the same line as the first sentence in the paragraph they encapsulate.
- Paragraphs are now separated by an empty new line.
- <em> tags are no longer followed by multiple white spaces.
