### PR TITLE
Generating classes in their own packages

### DIFF
--- a/library/src/main/java/com/squareup/otto/ReflectionFinder.java
+++ b/library/src/main/java/com/squareup/otto/ReflectionFinder.java
@@ -17,6 +17,9 @@
 
 package com.squareup.otto;
 
+import com.squareup.otto.internal.Finder;
+import com.squareup.otto.internal.Producer;
+import com.squareup.otto.internal.Subscriber;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
@@ -171,7 +174,7 @@ class ReflectionFinder implements Finder {
     return handlersInMethod;
   }
 
-  @Override public void install(Object instance, BasicBus bus) {
+  @Override public void install(Object instance, BasicBus.Installer bus) {
     Map<Class<?>, Producer> foundProducers = findAllProducers(instance);
     for (Map.Entry<Class<?>, Producer> entry : foundProducers.entrySet()) {
       bus.installProducer(entry.getKey(), entry.getValue());
@@ -186,7 +189,7 @@ class ReflectionFinder implements Finder {
     }
   }
 
-  @Override public void uninstall(Object instance, BasicBus bus) {
+  @Override public void uninstall(Object instance, BasicBus.Installer bus) {
     Map<Class<?>, Producer> foundProducers = findAllProducers(instance);
     for (Class<?> key : foundProducers.keySet()) {
       bus.uninstallProducer(key);

--- a/library/src/main/java/com/squareup/otto/ReflectionProducer.java
+++ b/library/src/main/java/com/squareup/otto/ReflectionProducer.java
@@ -16,6 +16,7 @@
 
 package com.squareup.otto;
 
+import com.squareup.otto.internal.Producer;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 

--- a/library/src/main/java/com/squareup/otto/ReflectionSubscriber.java
+++ b/library/src/main/java/com/squareup/otto/ReflectionSubscriber.java
@@ -17,6 +17,7 @@
 
 package com.squareup.otto;
 
+import com.squareup.otto.internal.Subscriber;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 

--- a/library/src/main/java/com/squareup/otto/internal/Finder.java
+++ b/library/src/main/java/com/squareup/otto/internal/Finder.java
@@ -13,18 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.squareup.otto;
+package com.squareup.otto.internal;
 
-import java.lang.reflect.InvocationTargetException;
+import com.squareup.otto.BasicBus;
 
 /**
- * Represents an instance that can produce events of the specified type.
+ * An object which manages the installation and uninstallation of {@link Subscriber Subscribers}
+ * and {@link Producer Producers} for another type.
  *
  * @author Jake Wharton
  */
-interface Producer<T> {
-  T produce() throws InvocationTargetException;
+public interface Finder<T> {
+  /** Add all subscribers and producers for the supplied {@code instance} to the bus. */
+  void install(T instance, BasicBus.Installer bus);
 
-  /** Invalidate this object so that subsequent calls to {@link #produce()} are no-ops. */
-  void invalidate();
+  /** Remove all subscribers and producers for the supplied {@code instance} from the bus. */
+  void uninstall(T instance, BasicBus.Installer bus);
 }

--- a/library/src/main/java/com/squareup/otto/internal/Producer.java
+++ b/library/src/main/java/com/squareup/otto/internal/Producer.java
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.squareup.otto;
+package com.squareup.otto.internal;
 
 import java.lang.reflect.InvocationTargetException;
 
 /**
- * Represents an instance that can handle events of the specified type.
+ * Represents an instance that can produce events of the specified type.
  *
  * @author Jake Wharton
  */
-interface Subscriber<T> {
-  void handle(T event) throws InvocationTargetException;
+public interface Producer<T> {
+  T produce() throws InvocationTargetException;
 
-  /** Invalidate this object so that subsequent calls to {@link #handle(T)} are no-ops. */
+  /** Invalidate this object so that subsequent calls to {@link #produce()} are no-ops. */
   void invalidate();
 }

--- a/library/src/main/java/com/squareup/otto/internal/Subscriber.java
+++ b/library/src/main/java/com/squareup/otto/internal/Subscriber.java
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.squareup.otto;
+package com.squareup.otto.internal;
+
+import java.lang.reflect.InvocationTargetException;
 
 /**
- * An object which manages the installation and uninstallation of {@link Subscriber Subscribers}
- * and {@link Producer Producers} for another type.
+ * Represents an instance that can handle events of the specified type.
  *
  * @author Jake Wharton
  */
-interface Finder<T> {
-  /** Add all subscribers and producers for the supplied {@code instance} to the bus. */
-  void install(T instance, BasicBus bus);
+public interface Subscriber<T> {
+  void handle(T event) throws InvocationTargetException;
 
-  /** Remove all subscribers and producers for the supplied {@code instance} from the bus. */
-  void uninstall(T instance, BasicBus bus);
+  /** Invalidate this object so that subsequent calls to {@link #handle(T)} are no-ops. */
+  void invalidate();
 }

--- a/library/src/main/java/com/squareup/otto/internal/Target.java
+++ b/library/src/main/java/com/squareup/otto/internal/Target.java
@@ -16,8 +16,8 @@
 package com.squareup.otto.internal;
 
 /**
- * Base class for generated {@link com.squareup.otto.Producer} and {@link
- * com.squareup.otto.Subscriber} implementations which hold a reference to a target object.
+ * Base class for generated {@link Producer} and {@link
+ * Subscriber} implementations which hold a reference to a target object.
  *
  * @author Jake Wharton
  */

--- a/library/src/test/java/com/squareup/otto/BasicBusTest.java
+++ b/library/src/test/java/com/squareup/otto/BasicBusTest.java
@@ -16,6 +16,7 @@
 
 package com.squareup.otto;
 
+import com.squareup.otto.internal.Subscriber;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/library/src/test/java/com/squareup/otto/UnregisteringHandlerTest.java
+++ b/library/src/test/java/com/squareup/otto/UnregisteringHandlerTest.java
@@ -16,6 +16,9 @@
 
 package com.squareup.otto;
 
+import com.squareup.otto.internal.Finder;
+import com.squareup.otto.internal.Producer;
+import com.squareup.otto.internal.Subscriber;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Map;
@@ -110,12 +113,11 @@ public class UnregisteringHandlerTest {
       }
     };
 
-    @Override public void install(Object instance, BasicBus bus) {
-      BasicBus basicBus = (BasicBus) bus;
+    @Override public void install(Object instance, BasicBus.Installer bus) {
 
       Map<Class<?>, Producer> foundProducers = findAllProducers(instance);
       for (Map.Entry<Class<?>, Producer> entry : foundProducers.entrySet()) {
-        basicBus.installProducer(entry.getKey(), entry.getValue());
+        bus.installProducer(entry.getKey(), entry.getValue());
       }
 
       Map<Class<?>, Set<Subscriber>> foundSubscribers = findAllSubscribers(instance);
@@ -124,7 +126,7 @@ public class UnregisteringHandlerTest {
         sorted.addAll(entry.getValue());
         Class<?> type = entry.getKey();
         for (Subscriber foundSubscriber : sorted) {
-          basicBus.installSubscriber(type, foundSubscriber);
+          bus.installSubscriber(type, foundSubscriber);
         }
       }
     }


### PR DESCRIPTION
- Enables default scope for `@Subscribe` and `@Produce` methods
- Prevents name conflicts
- Finder, Producer and Subscriber now need to be public, and are therefore moved to the internal package.
- BasicBus install and uninstall methods need to be accessed from another package and must not be made public (therefore no interface). This patch introduces an Installer inner class as a trojan.
