### PR TITLE
added support for inheritance

### DIFF
--- a/library/src/main/java/com/squareup/otto/ProcessSuperClass.java
+++ b/library/src/main/java/com/squareup/otto/ProcessSuperClass.java
@@ -1,0 +1,16 @@
+package com.squareup.otto;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Allows a class to tell otto to look for {@link Produce} and {@link Subscribe} annotated methods in super classes.
+ * Recursion only proceeds on classes which are annotated with this annotation, meaning in an inheritance
+ * hierarchy each sub-class must have this annotation.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ProcessSuperClass {
+}

--- a/library/src/test/java/com/squareup/otto/ProcessSuperClassTest.java
+++ b/library/src/test/java/com/squareup/otto/ProcessSuperClassTest.java
@@ -1,0 +1,55 @@
+package com.squareup.otto;
+
+import org.junit.Test;
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class ProcessSuperClassTest {
+
+  private final Bus bus = new Bus(ThreadEnforcer.ANY, "test-bus");
+
+  @Test
+  public void allowsSuperClassSubscription() {
+
+    class Parent {
+
+      protected boolean messageReceived;
+
+      @Subscribe
+      public void onMessage(String message) {
+        messageReceived = true;
+      }
+    }
+
+    @ProcessSuperClass
+    class Child extends Parent {}
+
+    final Child child = new Child();
+    bus.register(child);
+    bus.post("Foo");
+
+    assertThat(child.messageReceived).isTrue();
+  }
+
+  @Test
+  public void doesNotProcessSuperClassWhenAnnotationIsMissing() {
+
+    class Parent {
+
+      protected boolean messageReceived;
+
+      @Subscribe
+      public void onMessage(String message) {
+        messageReceived = true;
+      }
+    }
+
+    class Child extends Parent {}
+
+    final Child child = new Child();
+    bus.register(child);
+    bus.post("Foo");
+
+    assertThat(child.messageReceived).isFalse();
+  }
+
+}

--- a/website/index.html
+++ b/website/index.html
@@ -76,10 +76,13 @@
             to an instance of the class in which the previous method was present, we can register using the
             following:</p>
             <pre class="prettyprint">bus.register(this);</pre>
-            <p><strong>Registering will only find methods on the immediate class type.</strong> Unlike the Guava event
+            <p><strong>Registering defaults to only find methods on the immediate class type.</strong> Unlike the Guava event
             bus, Otto will not traverse the class hierarchy and add methods from base classes or interfaces that are
             annotated. This is an explicit design decision to improve performance of the library as well as keep your
             code simple and unambiguous.</p>
+            <p>In case you want to register inherited methods anyway you can annotate your classes with
+            <code>@ProcessSuperClass</code>. Otto will recursively traverse the inheritance hierarchy until it finds a class
+            which is not being annotated with this annotation or no more super classes can be found.</p>
             <p>Remember to also call the <code>unregister</code> method when appropriate. See the sample application
             included in the download for a complete example.</p>
 


### PR DESCRIPTION
This is a solution to the limitation that otto only processes methods of the immediate type, disregarding any annotated super methods. This topic has been discussed [here](https://github.com/square/otto/issues/26).

This pull request adds an annotation to the public API of otto which allows the user to explicitly declare classes for which otto should check super classes for annotations (producers/subscribers).

Credits for the original implementation of this pull request go to @deadfalkon.