### PR TITLE
Otto library without any Android dependency.

### DIFF
--- a/library-android/pom.xml
+++ b/library-android/pom.xml
@@ -25,11 +25,23 @@
   </parent>
 
   <groupId>com.squareup</groupId>
-  <artifactId>otto-vanilla</artifactId>
+  <artifactId>otto</artifactId>
   <packaging>jar</packaging>
-  <name>Otto without Android dependency</name>
+  <name>Otto</name>
 
   <dependencies>
+    <dependency>
+      <groupId>com.google.android</groupId>
+      <artifactId>android</artifactId>
+      <scope>provided</scope>
+    </dependency>
+	
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>otto-vanilla</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/library-android/src/main/java/com/squareup/otto/Bus.java
+++ b/library-android/src/main/java/com/squareup/otto/Bus.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2012 Square, Inc.
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.otto;
+
+/**
+ * Dispatches events to listeners, and provides ways for listeners to register themselves.
+ *
+ * <p>The Bus allows publish-subscribe-style communication between components without requiring the components to
+ * explicitly register with one another (and thus be aware of each other).  It is designed exclusively to replace
+ * traditional Android in-process event distribution using explicit registration or listeners. It is <em>not</em> a
+ * general-purpose publish-subscribe system, nor is it intended for interprocess communication.
+ *
+ * <h2>Receiving Events</h2>
+ * To receive events, an object should:
+ * <ol>
+ * <li>Expose a public method, known as the <i>event handler</i>, which accepts a single argument of the type of event
+ * desired;</li>
+ * <li>Mark it with a {@link Subscribe} annotation;</li>
+ * <li>Pass itself to an Bus instance's {@link #register(Object)} method.
+ * </li>
+ * </ol>
+ *
+ * <h2>Posting Events</h2>
+ * To post an event, simply provide the event object to the {@link #post(Object)} method.  The Bus instance will
+ * determine the type of event and route it to all registered listeners.
+ *
+ * <p>Events are routed based on their type &mdash; an event will be delivered to any handler for any type to which the
+ * event is <em>assignable.</em>  This includes implemented interfaces, all superclasses, and all interfaces implemented
+ * by superclasses.
+ *
+ * <p>When {@code post} is called, all registered handlers for an event are run in sequence, so handlers should be
+ * reasonably quick.  If an event may trigger an extended process (such as a database load), spawn a thread or queue it
+ * for later.
+ *
+ * <h2>Handler Methods</h2>
+ * Event handler methods must accept only one argument: the event.
+ *
+ * <p>Handlers should not, in general, throw.  If they do, the Bus will wrap the exception and
+ * re-throw it.
+ *
+ * <p>The Bus by default enforces that all interactions occur on the main thread.  You can provide an alternate
+ * enforcement by passing a {@link ThreadEnforcer} to the constructor.
+ *
+ * <h2>Producer Methods</h2>
+ * Producer methods should accept no arguments and return their event type. When a subscriber is registered for a type
+ * that a producer is also already registered for, the subscriber will be called with the return value from the
+ * producer.
+ *
+ * <h2>Dead Events</h2>
+ * If an event is posted, but no registered handlers can accept it, it is considered "dead."  To give the system a
+ * second chance to handle dead events, they are wrapped in an instance of {@link DeadEvent} and
+ * reposted.
+ *
+ * <p>This class is safe for concurrent use.
+ *
+ * @author Cliff Biffle
+ * @author Jake Wharton
+ * @author Francisco Javier Fernandez
+ */
+public class Bus extends com.squareup.otto.vanilla.Bus {
+
+    /**
+     * Creates a new Bus with the given {@code identifier} that enforces Main thread for its actions.
+     *
+     * @param identifier a brief name for this bus, for debugging purposes.  Should be a valid Java identifier.
+     */
+    public Bus(String identifier) {
+        super(ThreadEnforcer.MAIN, identifier);
+    }
+}

--- a/library-android/src/main/java/com/squareup/otto/Bus.java
+++ b/library-android/src/main/java/com/squareup/otto/Bus.java
@@ -74,6 +74,11 @@ package com.squareup.otto;
  */
 public class Bus extends com.squareup.otto.vanilla.Bus {
 
+    /** Creates a new Bus named "default" that enforces actions on the main thread. */
+    public Bus() {
+        this(DEFAULT_IDENTIFIER);
+    }
+
     /**
      * Creates a new Bus with the given {@code identifier} that enforces Main thread for its actions.
      *

--- a/library-android/src/main/java/com/squareup/otto/ThreadEnforcer.java
+++ b/library-android/src/main/java/com/squareup/otto/ThreadEnforcer.java
@@ -1,0 +1,39 @@
+package com.squareup.otto;
+
+import android.os.Looper;
+import com.squareup.otto.vanilla.Bus;
+
+/**
+ * Enforces a thread confinement policy for methods on a particular event bus.
+ *
+ * @author Jake Wharton
+ * @author Francisco Javier Fernandez
+ */
+public interface ThreadEnforcer extends com.squareup.otto.vanilla.ThreadEnforcer {
+
+    /**
+     * Enforce a valid thread for the given {@code bus}. Implementations may throw any runtime exception.
+     *
+     * @param bus Event bus instance on which an action is being performed.
+     */
+    void enforce(Bus bus);
+
+
+    /** A {@link ThreadEnforcer} that does no verification. */
+    ThreadEnforcer ANY = new ThreadEnforcer() {
+        @Override public void enforce(Bus bus) {
+            // Allow any thread.
+        }
+    };
+
+    /** A {@link ThreadEnforcer} that confines {@link Bus} methods to the main thread. */
+    ThreadEnforcer MAIN = new ThreadEnforcer() {
+        @Override public void enforce(Bus bus) {
+            if (Looper.myLooper() != Looper.getMainLooper()) {
+                throw new IllegalStateException("Event bus " + bus
+                        + " accessed from non-main thread " + Looper.myLooper());
+            }
+        }
+    };
+
+}

--- a/library/src/main/java/com/squareup/otto/Produce.java
+++ b/library/src/main/java/com/squareup/otto/Produce.java
@@ -22,10 +22,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a method as an instance producer, as used by {@link AnnotatedHandlerFinder} and {@link Bus}.
+ * Marks a method as an instance producer, as used by {@link com.squareup.otto.vanilla.AnnotatedHandlerFinder}
+ * and {@link com.squareup.otto.vanilla.Bus}.
  * <p>
  * Otto infers the instance type from the annotated method's return type. Producer methods may return null when there is
- * no appropriate value to share. The calling {@link Bus} ignores such returns and posts nothing.
+ * no appropriate value to share. The calling {@link com.squareup.otto.vanilla.Bus} ignores such returns
+ * and posts nothing.
  *
  * @author Jake Wharton
  */

--- a/library/src/main/java/com/squareup/otto/Subscribe.java
+++ b/library/src/main/java/com/squareup/otto/Subscribe.java
@@ -22,12 +22,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a method as an event handler, as used by {@link AnnotatedHandlerFinder} and {@link Bus}.
+ * Marks a method as an event handler, as used by {@link com.squareup.otto.vanilla.AnnotatedHandlerFinder}
+ * and {@link com.squareup.otto.vanilla.Bus}.
  *
  * <p>The method's first (and only) parameter defines the event type.
  * <p>If this annotation is applied to methods with zero parameters or more than one parameter, the object containing
- * the method will not be able to register for event delivery from the {@link Bus}. Otto fails fast by throwing
- * runtime exceptions in these cases.
+ * the method will not be able to register for event delivery from the {@link com.squareup.otto.vanilla.Bus}.
+ * Otto fails fast by throwing runtime exceptions in these cases.
  *
  * @author Cliff Biffle
  */

--- a/library/src/main/java/com/squareup/otto/vanilla/AnnotatedHandlerFinder.java
+++ b/library/src/main/java/com/squareup/otto/vanilla/AnnotatedHandlerFinder.java
@@ -15,7 +15,10 @@
  * limitations under the License.
  */
 
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
+
+import com.squareup.otto.Produce;
+import com.squareup.otto.Subscribe;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -25,7 +28,8 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Helper methods for finding methods annotated with {@link Produce} and {@link Subscribe}.
+ * Helper methods for finding methods annotated with {@link com.squareup.otto.Produce}
+ * and {@link com.squareup.otto.Subscribe}.
  *
  * @author Cliff Biffle
  * @author Louis Wasserman
@@ -42,7 +46,8 @@ final class AnnotatedHandlerFinder {
       new HashMap<Class<?>, Map<Class<?>, Set<Method>>>();
 
   /**
-   * Load all methods annotated with {@link Produce} or {@link Subscribe} into their respective caches for the
+   * Load all methods annotated with {@link com.squareup.otto.Produce} or
+   * {@link com.squareup.otto.Subscribe} into their respective caches for the
    * specified class.
    */
   private static void loadAnnotatedMethods(Class<?> listenerClass) {

--- a/library/src/main/java/com/squareup/otto/vanilla/Bus.java
+++ b/library/src/main/java/com/squareup/otto/vanilla/Bus.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
@@ -77,7 +77,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
  *
  * <h2>Dead Events</h2>
  * If an event is posted, but no registered handlers can accept it, it is considered "dead."  To give the system a
- * second chance to handle dead events, they are wrapped in an instance of {@link com.squareup.otto.DeadEvent} and
+ * second chance to handle dead events, they are wrapped in an instance of {@link DeadEvent} and
  * reposted.
  *
  * <p>This class is safe for concurrent use.
@@ -131,7 +131,7 @@ public class Bus {
    * @param identifier a brief name for this bus, for debugging purposes.  Should be a valid Java identifier.
    */
   public Bus(String identifier) {
-    this(ThreadEnforcer.MAIN, identifier);
+    this(ThreadEnforcer.ANY, identifier);
   }
 
   /**

--- a/library/src/main/java/com/squareup/otto/vanilla/DeadEvent.java
+++ b/library/src/main/java/com/squareup/otto/vanilla/DeadEvent.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
 
 /**
  * Wraps an event that was posted, but which had no subscribers and thus could not be delivered.

--- a/library/src/main/java/com/squareup/otto/vanilla/EventHandler.java
+++ b/library/src/main/java/com/squareup/otto/vanilla/EventHandler.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/library/src/main/java/com/squareup/otto/vanilla/EventProducer.java
+++ b/library/src/main/java/com/squareup/otto/vanilla/EventProducer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/library/src/main/java/com/squareup/otto/vanilla/HandlerFinder.java
+++ b/library/src/main/java/com/squareup/otto/vanilla/HandlerFinder.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
 
 import java.util.Map;
 import java.util.Set;

--- a/library/src/main/java/com/squareup/otto/vanilla/ThreadEnforcer.java
+++ b/library/src/main/java/com/squareup/otto/vanilla/ThreadEnforcer.java
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-package com.squareup.otto;
-
-import android.os.Looper;
+package com.squareup.otto.vanilla;
 
 /**
  * Enforces a thread confinement policy for methods on a particular event bus.
@@ -37,15 +35,6 @@ public interface ThreadEnforcer {
   ThreadEnforcer ANY = new ThreadEnforcer() {
     @Override public void enforce(Bus bus) {
       // Allow any thread.
-    }
-  };
-
-  /** A {@link ThreadEnforcer} that confines {@link Bus} methods to the main thread. */
-  ThreadEnforcer MAIN = new ThreadEnforcer() {
-    @Override public void enforce(Bus bus) {
-      if (Looper.myLooper() != Looper.getMainLooper()) {
-        throw new IllegalStateException("Event bus " + bus + " accessed from non-main thread " + Looper.myLooper());
-      }
     }
   };
 

--- a/library/src/test/java/com/squareup/otto/outside/AnnotatedHandlerFinderTest.java
+++ b/library/src/test/java/com/squareup/otto/outside/AnnotatedHandlerFinderTest.java
@@ -16,9 +16,9 @@
 
 package com.squareup.otto.outside;
 
-import com.squareup.otto.Bus;
+import com.squareup.otto.vanilla.Bus;
 import com.squareup.otto.Subscribe;
-import com.squareup.otto.ThreadEnforcer;
+import com.squareup.otto.vanilla.ThreadEnforcer;
 
 import org.junit.After;
 import org.junit.Before;

--- a/library/src/test/java/com/squareup/otto/outside/AnnotatedProducerFinderTest.java
+++ b/library/src/test/java/com/squareup/otto/outside/AnnotatedProducerFinderTest.java
@@ -16,10 +16,10 @@
 
 package com.squareup.otto.outside;
 
-import com.squareup.otto.Bus;
+import com.squareup.otto.vanilla.Bus;
 import com.squareup.otto.Produce;
 import com.squareup.otto.Subscribe;
-import com.squareup.otto.ThreadEnforcer;
+import com.squareup.otto.vanilla.ThreadEnforcer;
 import org.junit.Test;
 
 import java.util.ArrayList;

--- a/library/src/test/java/com/squareup/otto/outside/OutsideEventBusTest.java
+++ b/library/src/test/java/com/squareup/otto/outside/OutsideEventBusTest.java
@@ -16,9 +16,9 @@
 
 package com.squareup.otto.outside;
 
-import com.squareup.otto.Bus;
+import com.squareup.otto.vanilla.Bus;
 import com.squareup.otto.Subscribe;
-import com.squareup.otto.ThreadEnforcer;
+import com.squareup.otto.vanilla.ThreadEnforcer;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/library/src/test/java/com/squareup/otto/vanilla/BusTest.java
+++ b/library/src/test/java/com/squareup/otto/vanilla/BusTest.java
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
 
+import com.squareup.otto.Produce;
+import com.squareup.otto.Subscribe;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,7 +33,7 @@ import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 
 /**
- * Test case for {@link Bus}.
+ * Test case for {@link com.squareup.otto.vanilla.Bus}.
  *
  * @author Cliff Biffle
  */
@@ -76,7 +78,8 @@ public class BusTest {
     final List<Object> objectEvents = new ArrayList<Object>();
     Object objCatcher = new Object() {
       @SuppressWarnings("unused")
-      @Subscribe public void eat(Object food) {
+      @Subscribe
+      public void eat(Object food) {
         objectEvents.add(food);
       }
     };
@@ -205,7 +208,8 @@ public class BusTest {
     }
     try {
       bus.register(new Object() {
-        @Produce protected Object method() { return null; }
+        @Produce
+        protected Object method() { return null; }
       });
       fail();
     } catch (IllegalArgumentException expected) {

--- a/library/src/test/java/com/squareup/otto/vanilla/EventBusInnerClassStressTest.java
+++ b/library/src/test/java/com/squareup/otto/vanilla/EventBusInnerClassStressTest.java
@@ -1,12 +1,13 @@
 // Copyright 2012 Square, Inc.
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
 
+import com.squareup.otto.Subscribe;
 import org.junit.Test;
 
 import static junit.framework.Assert.assertTrue;
 
 /**
- * Stress test of {@link Bus} against inner classes. The anon inner class tests
+ * Stress test of {@link com.squareup.otto.vanilla.Bus} against inner classes. The anon inner class tests
  * were broken when we switched to weak references.
  *
  * @author Ray Ryan (ray@squareup.com)

--- a/library/src/test/java/com/squareup/otto/vanilla/EventHandlerTest.java
+++ b/library/src/test/java/com/squareup/otto/vanilla/EventHandlerTest.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
 
+import com.squareup.otto.vanilla.EventHandler;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/library/src/test/java/com/squareup/otto/vanilla/EventProducerTest.java
+++ b/library/src/test/java/com/squareup/otto/vanilla/EventProducerTest.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
 
+import com.squareup.otto.vanilla.EventProducer;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/library/src/test/java/com/squareup/otto/vanilla/LazyStringProducer.java
+++ b/library/src/test/java/com/squareup/otto/vanilla/LazyStringProducer.java
@@ -1,4 +1,6 @@
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
+
+import com.squareup.otto.Produce;
 
 public class LazyStringProducer {
   public String value = null;

--- a/library/src/test/java/com/squareup/otto/vanilla/ReentrantEventsTest.java
+++ b/library/src/test/java/com/squareup/otto/vanilla/ReentrantEventsTest.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
 
+import com.squareup.otto.Subscribe;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -26,7 +27,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
 /**
- * Validate that {@link Bus} behaves carefully when listeners publish
+ * Validate that {@link com.squareup.otto.vanilla.Bus} behaves carefully when listeners publish
  * their own events.
  *
  * @author Jesse Wilson

--- a/library/src/test/java/com/squareup/otto/vanilla/StringCatcher.java
+++ b/library/src/test/java/com/squareup/otto/vanilla/StringCatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Square, Inc.
+ * Copyright (C) 2007 The Guava Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,35 +14,33 @@
  * limitations under the License.
  */
 
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
 
 import java.util.ArrayList;
 import java.util.List;
 
-/** An EventHandler mock that records a String and unregisters itself in the handler. */
-public class UnregisteringStringCatcher {
-  private final Bus bus;
+import com.squareup.otto.Subscribe;
+import junit.framework.Assert;
 
+/**
+ * A simple EventHandler mock that records Strings.
+ *
+ * For testing fun, also includes a landmine method that Bus tests are
+ * required <em>not</em> to call ({@link #methodWithoutAnnotation(String)}).
+ *
+ * @author Cliff Biffle
+ */
+public class StringCatcher {
   private List<String> events = new ArrayList<String>();
 
-  public UnregisteringStringCatcher(Bus bus) {
-    this.bus = bus;
+  @Subscribe
+  public void hereHaveAString(String string) {
+    events.add(string);
   }
 
-  @Subscribe public void unregisterOnString(String event) {
-    bus.unregister(this);
-    events.add(event);
+  public void methodWithoutAnnotation(String string) {
+    Assert.fail("Event bus must not call methods without @Subscribe!");
   }
-
-  @Subscribe public void zzzSleepinOnStrings(String event) {
-    events.add(event);
-  }
-
-  @Subscribe public void haveAnInteger(Integer event) {}
-
-  @Subscribe public void enjoyThisLong(Long event) {}
-
-  @Subscribe public void perhapsATastyDouble(Double event) {}
 
   public List<String> getEvents() {
     return events;

--- a/library/src/test/java/com/squareup/otto/vanilla/StringProducer.java
+++ b/library/src/test/java/com/squareup/otto/vanilla/StringProducer.java
@@ -1,4 +1,6 @@
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
+
+import com.squareup.otto.Produce;
 
 public class StringProducer {
   public static final String VALUE = "Hello, Producer";

--- a/library/src/test/java/com/squareup/otto/vanilla/ThreadEnforcerTest.java
+++ b/library/src/test/java/com/squareup/otto/vanilla/ThreadEnforcerTest.java
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
 
+import com.squareup.otto.vanilla.Bus;
+import com.squareup.otto.vanilla.ThreadEnforcer;
 import org.junit.Test;
 
 import static junit.framework.Assert.assertFalse;

--- a/library/src/test/java/com/squareup/otto/vanilla/UnregisteringHandlerTest.java
+++ b/library/src/test/java/com/squareup/otto/vanilla/UnregisteringHandlerTest.java
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
 
+import com.squareup.otto.Produce;
+import com.squareup.otto.Subscribe;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -68,7 +70,8 @@ public class UnregisteringHandlerTest {
   @Test public void unregisterProducerInHandler() throws Exception {
     final Object producer = new Object() {
       private int calls = 0;
-      @Produce public String produceString() {
+      @Produce
+      public String produceString() {
         calls++;
         if (calls > 1) {
           fail("Should only have been called once, then unregistered and never called again.");
@@ -78,7 +81,8 @@ public class UnregisteringHandlerTest {
     };
     bus.register(producer);
     bus.register(new Object() {
-      @Subscribe public void firstUnsubscribeTheProducer(String produced) {
+      @Subscribe
+      public void firstUnsubscribeTheProducer(String produced) {
         bus.unregister(producer);
       }
       @Subscribe public void shouldNeverBeCalled(String uhoh) {

--- a/library/src/test/java/com/squareup/otto/vanilla/UnregisteringStringCatcher.java
+++ b/library/src/test/java/com/squareup/otto/vanilla/UnregisteringStringCatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007 The Guava Authors
+ * Copyright (C) 2012 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,31 +14,37 @@
  * limitations under the License.
  */
 
-package com.squareup.otto;
+package com.squareup.otto.vanilla;
+
+import com.squareup.otto.Subscribe;
 
 import java.util.ArrayList;
 import java.util.List;
-import junit.framework.Assert;
 
-/**
- * A simple EventHandler mock that records Strings.
- *
- * For testing fun, also includes a landmine method that Bus tests are
- * required <em>not</em> to call ({@link #methodWithoutAnnotation(String)}).
- *
- * @author Cliff Biffle
- */
-public class StringCatcher {
+/** An EventHandler mock that records a String and unregisters itself in the handler. */
+public class UnregisteringStringCatcher {
+  private final Bus bus;
+
   private List<String> events = new ArrayList<String>();
 
-  @Subscribe
-  public void hereHaveAString(String string) {
-    events.add(string);
+  public UnregisteringStringCatcher(Bus bus) {
+    this.bus = bus;
   }
 
-  public void methodWithoutAnnotation(String string) {
-    Assert.fail("Event bus must not call methods without @Subscribe!");
+  @Subscribe public void unregisterOnString(String event) {
+    bus.unregister(this);
+    events.add(event);
   }
+
+  @Subscribe public void zzzSleepinOnStrings(String event) {
+    events.add(event);
+  }
+
+  @Subscribe public void haveAnInteger(Integer event) {}
+
+  @Subscribe public void enjoyThisLong(Long event) {}
+
+  @Subscribe public void perhapsATastyDouble(Double event) {}
 
   public List<String> getEvents() {
     return events;

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 
   <modules>
     <module>library</module>
+    <module>library-android</module>
     <module>sample</module>
   </modules>
 

--- a/sample/src/main/java/com/squareup/otto/sample/BusProvider.java
+++ b/sample/src/main/java/com/squareup/otto/sample/BusProvider.java
@@ -16,7 +16,7 @@
 
 package com.squareup.otto.sample;
 
-import com.squareup.otto.vanilla.Bus;
+import com.squareup.otto.Bus;
 
 /**
  * Maintains a singleton instance for obtaining the bus. Ideally this would be replaced with a more efficient means

--- a/sample/src/main/java/com/squareup/otto/sample/BusProvider.java
+++ b/sample/src/main/java/com/squareup/otto/sample/BusProvider.java
@@ -16,7 +16,7 @@
 
 package com.squareup.otto.sample;
 
-import com.squareup.otto.Bus;
+import com.squareup.otto.vanilla.Bus;
 
 /**
  * Maintains a singleton instance for obtaining the bus. Ideally this would be replaced with a more efficient means


### PR DESCRIPTION
Hi,

The idea behind this fork is to be able to use Otto with any Java project, without depending in Android. I'm working in projects that I would like reuse all the "plain" Java code between different platforms, and even though Guava seems a nice approach, I like Otto and its concise and lightweight philosophy. 

The only special thing Android requires is Thread confinement, to distinguish between Main thread or any other thread. Since all the mechanisms still the same, I've created a new module, with that particular scenario.

I've kept all the naming and namespaces, to have the ability to update the library without breaking backwards compatibility.

I know this fork is harder to admit than any other, for those "deeper" changes, but I wanted to open the discussion with a bit of code.

Any thoughts on this?

TY.