### PR TITLE
Ignore annotations on synthetic bridge methods.

### DIFF
--- a/library/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
+++ b/library/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
@@ -50,6 +50,13 @@ final class AnnotatedHandlerFinder {
     Map<Class<?>, Method> producerMethods = new HashMap<Class<?>, Method>();
 
     for (Method method : listenerClass.getDeclaredMethods()) {
+      // The compiler sometimes creates synthetic bridge methods as part of the
+      // type erasure process. As of JDK8 these methods now include the same
+      // annotations as the original declarations. They should be ignored for
+      // subscribe/produce.
+      if (method.isBridge()) {
+        continue;
+      }
       if (method.isAnnotationPresent(Subscribe.class)) {
         Class<?>[] parameterTypes = method.getParameterTypes();
         if (parameterTypes.length != 1) {

--- a/library/src/test/java/com/squareup/otto/BusTest.java
+++ b/library/src/test/java/com/squareup/otto/BusTest.java
@@ -402,4 +402,27 @@ public class BusTest {
     // Exists only for hierarchy mapping; no members.
   }
 
+  public static interface SubscriberInterface<T> {
+    @Subscribe
+    public abstract void subscribeToT(T value);
+  }
+
+  public static class SubscriberImpl implements SubscriberInterface<Number> {
+    @Subscribe
+    public void subscribeToT(Number value) {
+      // No numbers are expected to be published.
+      fail();
+    }
+
+    // javac creates a synthetic bridge method with an erased signature that is equivalent to:
+    // public void subscribeToT(Object value) {}
+    // As of java 8, the @Subscribe annotation will be copied over to the bridge method.
+  }
+
+  @Test public void ignoreSyntheticBridgeMethods() {
+    SubscriberImpl catcher = new SubscriberImpl();
+    bus.register(catcher);
+    bus.post(EVENT);
+  }
+
 }


### PR DESCRIPTION
This makes otto compatible with the JDK8 javac.
