### PR TITLE
Possibility to retrieve produced event without registering

### DIFF
--- a/otto/src/main/java/com/squareup/otto/Bus.java
+++ b/otto/src/main/java/com/squareup/otto/Bus.java
@@ -337,6 +337,31 @@ public class Bus {
   }
 
   /**
+   * <p>Produce and return one event for the provided type.</p>
+   * <p>This methode will not send this event to all registered listeners.
+   * It will juste ask the producer (if it exists) to produce the event and return the value to the caller.</p>
+   *
+   * @param type type of event to produce
+   * @return the current event value or {@code null} if no producer are currently registered for this event type.
+   */
+  public <T> T produce(Class<T> type) {
+    if (type == null) {
+      throw new NullPointerException("Type to produce must not be null.");
+    }
+    EventProducer producer = getProducerForEventType(type);
+    if (producer == null) {
+      return null;
+    }
+    try {
+      return (T) producer.produceEvent();
+    } catch (InvocationTargetException e) {
+      throwRuntimeException(
+              "Could not produce event: " + type, e);
+    }
+    return null;
+  }
+
+  /**
    * Queue the {@code event} for dispatch during {@link #dispatchQueuedEvents()}. Events are queued in-order of
    * occurrence so they can be dispatched in the same order.
    */

--- a/otto/src/test/java/com/squareup/otto/BusTest.java
+++ b/otto/src/test/java/com/squareup/otto/BusTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 
@@ -423,6 +424,17 @@ public class BusTest {
     SubscriberImpl catcher = new SubscriberImpl();
     bus.register(catcher);
     bus.post(EVENT);
+  }
+
+  @Test public void produceWithExistingProducer() {
+    StringProducer producer = new StringProducer();
+    bus.register(producer);
+
+    assertEquals(StringProducer.VALUE, bus.produce(String.class));
+  }
+
+  @Test public void produceWithNotExistingProducer() {
+    assertNull(bus.produce(Integer.class));
   }
 
 }


### PR DESCRIPTION
Producers in Otto are really useful to push states to any part of the code that needs it.
But sometimes, we just need this state once for any reason (save the state, display a notification, ...).
Actually, we must register(), wait for the event and unregister().

This is a simple method Bus.produce(type) that will return the current value from the producer for this event immediately.

This is my very first pull request so I hope I have all done right :).
