### PR TITLE
adding ability to detect  handlers from super class.

### DIFF
--- a/otto/src/main/java/com/squareup/otto/InheritSubscribers.java
+++ b/otto/src/main/java/com/squareup/otto/InheritSubscribers.java
@@ -1,0 +1,17 @@
+package com.squareup.otto;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: SG0891787
+ * Date: 1/6/2015
+ * Time: 8:05 PM
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface InheritSubscribers {
+}


### PR DESCRIPTION
When handler class is annotated with @InheritSubscribers during registration all DECLARED handler methods from super class will be added to subscribers list.  Handled methods from superclass's superclass
will not be added unless it also has @InheritSubscribers annotation.

As this functionality is explicitly requested by the user by placing InheritSubscribers annotation,
 user cannot complain on performance and code complexity.