### PR TITLE
Ensures flattenHierarchy() method is threadsafe for situations when the main thread enforcer is not active

### DIFF
--- a/otto/src/main/java/com/squareup/otto/Bus.java
+++ b/otto/src/main/java/com/squareup/otto/Bus.java
@@ -424,7 +424,7 @@ public class Bus {
       Set<Class<?>> classesCreation = getClassesFor(concreteClass);
       classes = flattenHierarchyCache.putIfAbsent(concreteClass, classesCreation);
       if (classes == null) {
-          classes = classesCreation;
+        classes = classesCreation;
       }
     }
 

--- a/otto/src/main/java/com/squareup/otto/Bus.java
+++ b/otto/src/main/java/com/squareup/otto/Bus.java
@@ -19,7 +19,6 @@ package com.squareup.otto;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -422,8 +421,11 @@ public class Bus {
   Set<Class<?>> flattenHierarchy(Class<?> concreteClass) {
     Set<Class<?>> classes = flattenHierarchyCache.get(concreteClass);
     if (classes == null) {
-      classes = getClassesFor(concreteClass);
-      flattenHierarchyCache.put(concreteClass, classes);
+      Set<Class<?>> classesCreation = getClassesFor(concreteClass);
+      classes = flattenHierarchyCache.putIfAbsent(concreteClass, classesCreation);
+      if(classes == null) {
+          classes = classesCreation;
+      }   
     }
 
     return classes;
@@ -461,8 +463,8 @@ public class Bus {
     }
   }
 
-  private final Map<Class<?>, Set<Class<?>>> flattenHierarchyCache =
-      new HashMap<Class<?>, Set<Class<?>>>();
+  private final ConcurrentMap<Class<?>, Set<Class<?>>> flattenHierarchyCache =
+      new ConcurrentHashMap<Class<?>, Set<Class<?>>>();
 
   /** Simple struct representing an event and its handler. */
   static class EventWithHandler {

--- a/otto/src/main/java/com/squareup/otto/Bus.java
+++ b/otto/src/main/java/com/squareup/otto/Bus.java
@@ -423,9 +423,9 @@ public class Bus {
     if (classes == null) {
       Set<Class<?>> classesCreation = getClassesFor(concreteClass);
       classes = flattenHierarchyCache.putIfAbsent(concreteClass, classesCreation);
-      if(classes == null) {
+      if (classes == null) {
           classes = classesCreation;
-      }   
+      }
     }
 
     return classes;


### PR DESCRIPTION
Use ConcurrentMap when building the class hierarchy so that if post() is called from multiple threads the Map's access is threadsafe.