### PR TITLE
Make static hashmaps thread safe

### DIFF
--- a/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
+++ b/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Helper methods for finding methods annotated with {@link Produce} and {@link Subscribe}.
@@ -34,12 +36,12 @@ import java.util.Set;
 final class AnnotatedHandlerFinder {
 
   /** Cache event bus producer methods for each class. */
-  private static final Map<Class<?>, Map<Class<?>, Method>> PRODUCERS_CACHE =
-      new HashMap<Class<?>, Map<Class<?>, Method>>();
+  private static final ConcurrentMap<Class<?>, Map<Class<?>, Method>> PRODUCERS_CACHE =
+      new ConcurrentHashMap<Class<?>, Map<Class<?>, Method>>();
 
   /** Cache event bus subscriber methods for each class. */
-  private static final Map<Class<?>, Map<Class<?>, Set<Method>>> SUBSCRIBERS_CACHE =
-      new HashMap<Class<?>, Map<Class<?>, Set<Method>>>();
+  private static final ConcurrentMap<Class<?>, Map<Class<?>, Set<Method>>> SUBSCRIBERS_CACHE =
+      new ConcurrentHashMap<Class<?>, Map<Class<?>, Set<Method>>>();
 
   /**
    * Load all methods annotated with {@link Produce} or {@link Subscribe} into their respective caches for the

--- a/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
+++ b/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
@@ -43,14 +43,21 @@ final class AnnotatedHandlerFinder {
   private static final ConcurrentMap<Class<?>, Map<Class<?>, Set<Method>>> SUBSCRIBERS_CACHE =
       new ConcurrentHashMap<Class<?>, Map<Class<?>, Set<Method>>>();
 
+  private static void loadAnnotatedProducerMethods(Class<?> listenerClass, Map<Class<?>, Method> producerMethods) {
+      Map<Class<?>, Set<Method>> subscriberMethods = new HashMap<Class<?>, Set<Method>>();
+      loadAnnotatedMethods(listenerClass, producerMethods, subscriberMethods);
+  }
+
+  private static void loadAnnotatedSubscriberMethods(Class<?> listenerClass, Map<Class<?>, Set<Method>> subscriberMethods) {
+      Map<Class<?>, Method> producerMethods = new HashMap<Class<?>, Method>();
+      loadAnnotatedMethods(listenerClass, producerMethods, subscriberMethods);
+  }
+
   /**
    * Load all methods annotated with {@link Produce} or {@link Subscribe} into their respective caches for the
    * specified class.
    */
-  private static void loadAnnotatedMethods(Class<?> listenerClass) {
-    Map<Class<?>, Set<Method>> subscriberMethods = new HashMap<Class<?>, Set<Method>>();
-    Map<Class<?>, Method> producerMethods = new HashMap<Class<?>, Method>();
-
+  private static void loadAnnotatedMethods(Class<?> listenerClass, Map<Class<?>, Method> producerMethods, Map<Class<?>, Set<Method>> subscriberMethods) {
     for (Method method : listenerClass.getDeclaredMethods()) {
       // The compiler sometimes creates synthetic bridge methods as part of the
       // type erasure process. As of JDK8 these methods now include the same
@@ -126,8 +133,8 @@ final class AnnotatedHandlerFinder {
 
     Map<Class<?>, Method> methods = PRODUCERS_CACHE.get(listenerClass);
     if (null == methods) {
-      loadAnnotatedMethods(listenerClass);
-      methods = PRODUCERS_CACHE.get(listenerClass);
+      methods = new HashMap<Class<?>, Method>();
+      loadAnnotatedProducerMethods(listenerClass, methods);
     }
     if (!methods.isEmpty()) {
       for (Map.Entry<Class<?>, Method> e : methods.entrySet()) {
@@ -146,8 +153,8 @@ final class AnnotatedHandlerFinder {
 
     Map<Class<?>, Set<Method>> methods = SUBSCRIBERS_CACHE.get(listenerClass);
     if (null == methods) {
-      loadAnnotatedMethods(listenerClass);
-      methods = SUBSCRIBERS_CACHE.get(listenerClass);
+      methods = new HashMap<Class<?>, Set<Method>>();
+      loadAnnotatedSubscriberMethods(listenerClass, methods);
     }
     if (!methods.isEmpty()) {
       for (Map.Entry<Class<?>, Set<Method>> e : methods.entrySet()) {

--- a/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
+++ b/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
@@ -37,27 +37,29 @@ final class AnnotatedHandlerFinder {
 
   /** Cache event bus producer methods for each class. */
   private static final ConcurrentMap<Class<?>, Map<Class<?>, Method>> PRODUCERS_CACHE =
-      new ConcurrentHashMap<Class<?>, Map<Class<?>, Method>>();
+    new ConcurrentHashMap<Class<?>, Map<Class<?>, Method>>();
 
   /** Cache event bus subscriber methods for each class. */
   private static final ConcurrentMap<Class<?>, Map<Class<?>, Set<Method>>> SUBSCRIBERS_CACHE =
-      new ConcurrentHashMap<Class<?>, Map<Class<?>, Set<Method>>>();
+    new ConcurrentHashMap<Class<?>, Map<Class<?>, Set<Method>>>();
 
   private static void loadAnnotatedProducerMethods(Class<?> listenerClass, Map<Class<?>, Method> producerMethods) {
-      Map<Class<?>, Set<Method>> subscriberMethods = new HashMap<Class<?>, Set<Method>>();
-      loadAnnotatedMethods(listenerClass, producerMethods, subscriberMethods);
+    Map<Class<?>, Set<Method>> subscriberMethods = new HashMap<Class<?>, Set<Method>>();
+    loadAnnotatedMethods(listenerClass, producerMethods, subscriberMethods);
   }
 
-  private static void loadAnnotatedSubscriberMethods(Class<?> listenerClass, Map<Class<?>, Set<Method>> subscriberMethods) {
-      Map<Class<?>, Method> producerMethods = new HashMap<Class<?>, Method>();
-      loadAnnotatedMethods(listenerClass, producerMethods, subscriberMethods);
+  private static void loadAnnotatedSubscriberMethods(Class<?> listenerClass, Map<Class<?>,
+      Set<Method>> subscriberMethods) {
+    Map<Class<?>, Method> producerMethods = new HashMap<Class<?>, Method>();
+    loadAnnotatedMethods(listenerClass, producerMethods, subscriberMethods);
   }
 
   /**
    * Load all methods annotated with {@link Produce} or {@link Subscribe} into their respective caches for the
    * specified class.
    */
-  private static void loadAnnotatedMethods(Class<?> listenerClass, Map<Class<?>, Method> producerMethods, Map<Class<?>, Set<Method>> subscriberMethods) {
+  private static void loadAnnotatedMethods(Class<?> listenerClass, Map<Class<?>, Method> producerMethods, Map<Class<?>,
+      Set<Method>> subscriberMethods) {
     for (Method method : listenerClass.getDeclaredMethods()) {
       // The compiler sometimes creates synthetic bridge methods as part of the
       // type erasure process. As of JDK8 these methods now include the same

--- a/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
+++ b/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
@@ -124,10 +124,11 @@ final class AnnotatedHandlerFinder {
     final Class<?> listenerClass = listener.getClass();
     Map<Class<?>, EventProducer> handlersInMethod = new HashMap<Class<?>, EventProducer>();
 
-    if (!PRODUCERS_CACHE.containsKey(listenerClass)) {
-      loadAnnotatedMethods(listenerClass);
-    }
     Map<Class<?>, Method> methods = PRODUCERS_CACHE.get(listenerClass);
+    if (null == methods) {
+      loadAnnotatedMethods(listenerClass);
+      methods = PRODUCERS_CACHE.get(listenerClass);
+    }
     if (!methods.isEmpty()) {
       for (Map.Entry<Class<?>, Method> e : methods.entrySet()) {
         EventProducer producer = new EventProducer(listener, e.getValue());
@@ -143,10 +144,11 @@ final class AnnotatedHandlerFinder {
     Class<?> listenerClass = listener.getClass();
     Map<Class<?>, Set<EventHandler>> handlersInMethod = new HashMap<Class<?>, Set<EventHandler>>();
 
-    if (!SUBSCRIBERS_CACHE.containsKey(listenerClass)) {
-      loadAnnotatedMethods(listenerClass);
-    }
     Map<Class<?>, Set<Method>> methods = SUBSCRIBERS_CACHE.get(listenerClass);
+    if (null == methods) {
+      loadAnnotatedMethods(listenerClass);
+      methods = SUBSCRIBERS_CACHE.get(listenerClass);
+    }
     if (!methods.isEmpty()) {
       for (Map.Entry<Class<?>, Set<Method>> e : methods.entrySet()) {
         Set<EventHandler> handlers = new HashSet<EventHandler>();


### PR DESCRIPTION
See issue https://github.com/square/otto/issues/148 .

This change makes the static producer/subscriber hashmaps thread safe.  

Note, there may be other parts that aren't thread safe but this covers what we've seen to be the most common issue.