### PR TITLE
Removing android dependencies, but still enforcing usage from same thread ID.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+Fork of Square Otto
+=============================
+https://github.com/square/otto
+
 Otto - An event bus by Square
 =============================
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Fork of Square Otto
 =============================
 https://github.com/square/otto
 
-Added feature of named event. 
+Added feature of named event.
 This allow multiple producer, productin same object type for different event name.
 As well as the subscriber will be able to subscribe event based on the name. 
 
@@ -23,6 +23,10 @@ bus.post('wifi_only_download', produceWifiConfigChange());
 ```
 
 Example above is just a very simple showcase of what can done with named event.
+
+
+Added feature for searching parent class for subscribe and produce annotation
+Based on https://github.com/thirogit/otto
 
 Otto - An event bus by Square
 =============================

--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@ Fork of Square Otto
 =============================
 https://github.com/square/otto
 
+Added feature of named event. 
+This allow multiple producer, productin same object type for different event name.
+As well as the subscriber will be able to subscribe event based on the name. 
+
+The ultimate conclusion of this changes is now you can use simple object like String or boolean with different name
+
+``` java
+@Subscriber(event = 'push_configuration');
+@Producer(event = 'push_configuration') producePushConfigChange();
+
+@Subscriber(event = 'wifi_only_download');
+@Producer(event = 'wifi_only_download') produceWifiConfigChange();
+
+bus.post('push_configuration', true);
+bus.post('push_configuration', producePushConfigChange());
+
+bus.post('wifi_only_download', true);
+bus.post('wifi_only_download', produceWifiConfigChange());
+```
+
+Example above is just a very simple showcase of what can done with named event.
+
 Otto - An event bus by Square
 =============================
 

--- a/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
+++ b/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
@@ -123,15 +123,16 @@ final class AnnotatedHandlerFinder {
               + " but is not 'public'.");
         }
 
-        if (producerMethods.containsKey(eventType)) {
-          throw new IllegalArgumentException("Producer for type " + eventType + " has already been registered.");
-        }
-
         Produce annotation = method.getAnnotation(Produce.class);
         String keyName = annotation.event();
         if ("".equals(keyName)) {
           keyName = eventType.getName();
         }
+
+        if (producerMethods.containsKey(keyName)) {
+          throw new IllegalArgumentException("Producer for type " + eventType + " has already been registered.");
+        }
+
         producerMethods.put(keyName, method);
       }
     }

--- a/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
+++ b/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
@@ -35,157 +35,186 @@ import java.util.concurrent.ConcurrentMap;
  */
 final class AnnotatedHandlerFinder {
 
-  /** Cache event bus producer methods for each class. */
-  private static final ConcurrentMap<Class<?>, Map<String, Method>> PRODUCERS_CACHE =
-          new ConcurrentHashMap<>();
+    /**
+     * Cache event bus producer methods for each class.
+     */
+    private static final ConcurrentMap<Class<?>, Map<String, Method>> PRODUCERS_CACHE =
+            new ConcurrentHashMap<>();
 
-  /** Cache event bus subscriber methods for each class. */
-  private static final ConcurrentMap<Class<?>, Map<String, Set<Method>>> SUBSCRIBERS_CACHE =
-          new ConcurrentHashMap<>();
+    /**
+     * Cache event bus subscriber methods for each class.
+     */
+    private static final ConcurrentMap<Class<?>, Map<String, Set<Method>>> SUBSCRIBERS_CACHE =
+            new ConcurrentHashMap<>();
 
-  private static void loadAnnotatedProducerMethods(Class<?> listenerClass,
-                                                   Map<String, Method> producerMethods) {
-    Map<String, Set<Method>> subscriberMethods = new HashMap<>();
-    loadAnnotatedMethods(listenerClass, producerMethods, subscriberMethods);
-  }
-
-  private static void loadAnnotatedSubscriberMethods(Class<?> listenerClass,
-                                                     Map<String, Set<Method>> subscriberMethods) {
-    Map<String, Method> producerMethods = new HashMap<>();
-    loadAnnotatedMethods(listenerClass, producerMethods, subscriberMethods);
-  }
-
-  /**
-   * Load all methods annotated with {@link Produce} or {@link Subscribe} into their respective caches for the
-   * specified class.
-   */
-  private static void loadAnnotatedMethods(Class<?> listenerClass, Map<String, Method> producerMethods, Map<String, Set<Method>> subscriberMethods) {
-    for (Method method : listenerClass.getDeclaredMethods()) {
-      // The compiler sometimes creates synthetic bridge methods as part of the
-      // type erasure process. As of JDK8 these methods now include the same
-      // annotations as the original declarations. They should be ignored for
-      // subscribe/produce.
-      if (method.isBridge()) {
-        continue;
-      }
-      if (method.isAnnotationPresent(Subscribe.class)) {
-        Class<?>[] parameterTypes = method.getParameterTypes();
-        if (parameterTypes.length != 1) {
-          throw new IllegalArgumentException("Method " + method + " has @Subscribe annotation but requires "
-              + parameterTypes.length + " arguments.  Methods must require a single argument.");
-        }
-
-        Class<?> eventType = parameterTypes[0];
-        if (eventType.isInterface()) {
-          throw new IllegalArgumentException("Method " + method + " has @Subscribe annotation on " + eventType
-              + " which is an interface.  Subscription must be on a concrete class type.");
-        }
-
-        if ((method.getModifiers() & Modifier.PUBLIC) == 0) {
-          throw new IllegalArgumentException("Method " + method + " has @Subscribe annotation on " + eventType
-              + " but is not 'public'.");
-        }
-
-        Subscribe annotation = method.getAnnotation(Subscribe.class);
-        String keyName = annotation.event();
-        if ("".equals(keyName)) {
-          keyName = eventType.getName();
-        }
-
-        Set<Method> methods = subscriberMethods.get(keyName);
-        if (methods == null) {
-          methods = new HashSet<Method>();
-          subscriberMethods.put(keyName, methods);
-        }
-        methods.add(method);
-      } else if (method.isAnnotationPresent(Produce.class)) {
-        Class<?>[] parameterTypes = method.getParameterTypes();
-        if (parameterTypes.length != 0) {
-          throw new IllegalArgumentException("Method " + method + "has @Produce annotation but requires "
-              + parameterTypes.length + " arguments.  Methods must require zero arguments.");
-        }
-        if (method.getReturnType() == Void.class) {
-          throw new IllegalArgumentException("Method " + method
-              + " has a return type of void.  Must declare a non-void type.");
-        }
-
-        Class<?> eventType = method.getReturnType();
-        if (eventType.isInterface()) {
-          throw new IllegalArgumentException("Method " + method + " has @Produce annotation on " + eventType
-              + " which is an interface.  Producers must return a concrete class type.");
-        }
-        if (eventType.equals(Void.TYPE)) {
-          throw new IllegalArgumentException("Method " + method + " has @Produce annotation but has no return type.");
-        }
-
-        if ((method.getModifiers() & Modifier.PUBLIC) == 0) {
-          throw new IllegalArgumentException("Method " + method + " has @Produce annotation on " + eventType
-              + " but is not 'public'.");
-        }
-
-        Produce annotation = method.getAnnotation(Produce.class);
-        String keyName = annotation.event();
-        if ("".equals(keyName)) {
-          keyName = eventType.getName();
-        }
-
-        if (producerMethods.containsKey(keyName)) {
-          throw new IllegalArgumentException("Producer for type " + eventType + " has already been registered.");
-        }
-
-        producerMethods.put(keyName, method);
-      }
+    private static void loadAnnotatedProducerMethods(Class<?> listenerClass,
+                                                     Map<String, Method> producerMethods) {
+        Map<String, Set<Method>> subscriberMethods = new HashMap<>();
+        loadAnnotatedMethods(listenerClass, producerMethods, subscriberMethods);
     }
 
-    PRODUCERS_CACHE.put(listenerClass, producerMethods);
-    SUBSCRIBERS_CACHE.put(listenerClass, subscriberMethods);
-  }
-
-  /** This implementation finds all methods marked with a {@link Produce} annotation. */
-  static Map<String, EventProducer> findAllProducers(Object listener) {
-    final Class<?> listenerClass = listener.getClass();
-    Map<String, EventProducer> handlersInMethod = new HashMap<>();
-
-    Map<String, Method> methods = PRODUCERS_CACHE.get(listenerClass);
-    if (null == methods) {
-      methods = new HashMap<>();
-      loadAnnotatedProducerMethods(listenerClass, methods);
-    }
-    if (!methods.isEmpty()) {
-      for (Map.Entry<String, Method> e : methods.entrySet()) {
-        EventProducer producer = new EventProducer(listener, e.getValue());
-        handlersInMethod.put(e.getKey(), producer);
-      }
+    private static void loadAnnotatedSubscriberMethods(Class<?> listenerClass,
+                                                       Map<String, Set<Method>> subscriberMethods) {
+        Map<String, Method> producerMethods = new HashMap<>();
+        loadAnnotatedMethods(listenerClass, producerMethods, subscriberMethods);
     }
 
-    return handlersInMethod;
-  }
+    /**
+     * Load all methods annotated with {@link Produce} or {@link Subscribe} into their respective caches for the
+     * specified class.
+     */
+    private static void loadAnnotatedMethods(Class<?> listenerClass, Map<String, Method> producerMethods, Map<String, Set<Method>> subscriberMethods) {
+        Class<?> clazz = listenerClass;
 
-  /** This implementation finds all methods marked with a {@link Subscribe} annotation. */
-  static Map<String, Set<EventHandler>> findAllSubscribers(Object listener) {
-    Class<?> listenerClass = listener.getClass();
-    Map<String, Set<EventHandler>> handlersInMethod = new HashMap<>();
+        do {
+            for (Method method : clazz.getDeclaredMethods())
+            {
+              // The compiler sometimes creates synthetic bridge methods as part of the
+              // type erasure process. As of JDK8 these methods now include the same
+              // annotations as the original declarations. They should be ignored for
+              // subscribe/produce.
+              if (method.isBridge())
+              {
+                continue;
+              }
+              if (method.isAnnotationPresent(Subscribe.class))
+              {
+                Class<?>[] parameterTypes = method.getParameterTypes();
+                if (parameterTypes.length != 1)
+                {
+                  throw new IllegalArgumentException("Method " + method + " has @Subscribe annotation but requires "
+                          + parameterTypes.length + " arguments.  Methods must require a single argument.");
+                }
 
-    Map<String, Set<Method>> methods = SUBSCRIBERS_CACHE.get(listenerClass);
-    if (null == methods) {
-      methods = new HashMap<>();
-      loadAnnotatedSubscriberMethods(listenerClass, methods);
+                Class<?> eventType = parameterTypes[0];
+                if (eventType.isInterface())
+                {
+                  throw new IllegalArgumentException("Method " + method + " has @Subscribe annotation on " + eventType
+                          + " which is an interface.  Subscription must be on a concrete class type.");
+                }
+
+                if ((method.getModifiers() & Modifier.PUBLIC) == 0)
+                {
+                  throw new IllegalArgumentException("Method " + method + " has @Subscribe annotation on " + eventType
+                          + " but is not 'public'.");
+                }
+
+                Subscribe annotation = method.getAnnotation(Subscribe.class);
+                String keyName = annotation.event();
+                if ("".equals(keyName))
+                {
+                  keyName = eventType.getName();
+                }
+
+                Set<Method> methods = subscriberMethods.get(keyName);
+                if (methods == null)
+                {
+                  methods = new HashSet<Method>();
+                  subscriberMethods.put(keyName, methods);
+                }
+                methods.add(method);
+              }
+              else if (method.isAnnotationPresent(Produce.class))
+              {
+                Class<?>[] parameterTypes = method.getParameterTypes();
+                if (parameterTypes.length != 0)
+                {
+                  throw new IllegalArgumentException("Method " + method + "has @Produce annotation but requires "
+                          + parameterTypes.length + " arguments.  Methods must require zero arguments.");
+                }
+                if (method.getReturnType() == Void.class)
+                {
+                  throw new IllegalArgumentException("Method " + method
+                          + " has a return type of void.  Must declare a non-void type.");
+                }
+
+                Class<?> eventType = method.getReturnType();
+                if (eventType.isInterface())
+                {
+                  throw new IllegalArgumentException("Method " + method + " has @Produce annotation on " + eventType
+                          + " which is an interface.  Producers must return a concrete class type.");
+                }
+                if (eventType.equals(Void.TYPE))
+                {
+                  throw new IllegalArgumentException("Method " + method + " has @Produce annotation but has no return type.");
+                }
+
+                Produce annotation = method.getAnnotation(Produce.class);
+                String keyName = annotation.event();
+                if ("".equals(keyName))
+                {
+                  keyName = eventType.getName();
+                }
+
+                if (producerMethods.containsKey(keyName))
+                {
+                  throw new IllegalArgumentException("Producer for type " + eventType + " has already been registered.");
+                }
+
+                producerMethods.put(keyName, method);
+              }
+            }
+
+            PRODUCERS_CACHE.put(listenerClass, producerMethods);
+            SUBSCRIBERS_CACHE.put(listenerClass, subscriberMethods);
+            if (clazz.isAnnotationPresent(InheritSubscribers.class)) {
+                clazz = clazz.getSuperclass();
+            } else {
+                clazz = null;
+            }
+        } while (clazz != null);
     }
-    if (!methods.isEmpty()) {
-      for (Map.Entry<String, Set<Method>> e : methods.entrySet()) {
-        Set<EventHandler> handlers = new HashSet<EventHandler>();
-        for (Method m : e.getValue()) {
-          handlers.add(new EventHandler(listener, m));
+
+
+    /**
+     * This implementation finds all methods marked with a {@link Produce} annotation.
+     */
+    static Map<String, EventProducer> findAllProducers(Object listener) {
+        final Class<?> listenerClass = listener.getClass();
+        Map<String, EventProducer> handlersInMethod = new HashMap<>();
+
+        Map<String, Method> methods = PRODUCERS_CACHE.get(listenerClass);
+        if (null == methods) {
+            methods = new HashMap<>();
+            loadAnnotatedProducerMethods(listenerClass, methods);
         }
-        handlersInMethod.put(e.getKey(), handlers);
-      }
+        if (!methods.isEmpty()) {
+            for (Map.Entry<String, Method> e : methods.entrySet()) {
+                EventProducer producer = new EventProducer(listener, e.getValue());
+                handlersInMethod.put(e.getKey(), producer);
+            }
+        }
+
+        return handlersInMethod;
     }
 
-    return handlersInMethod;
-  }
+    /**
+     * This implementation finds all methods marked with a {@link Subscribe} annotation.
+     */
+    static Map<String, Set<EventHandler>> findAllSubscribers(Object listener) {
+        Class<?> listenerClass = listener.getClass();
+        Map<String, Set<EventHandler>> handlersInMethod = new HashMap<>();
 
-  private AnnotatedHandlerFinder() {
-    // No instances.
-  }
+        Map<String, Set<Method>> methods = SUBSCRIBERS_CACHE.get(listenerClass);
+        if (null == methods) {
+            methods = new HashMap<>();
+            loadAnnotatedSubscriberMethods(listenerClass, methods);
+        }
+        if (!methods.isEmpty()) {
+            for (Map.Entry<String, Set<Method>> e : methods.entrySet()) {
+                Set<EventHandler> handlers = new HashSet<EventHandler>();
+                for (Method m : e.getValue()) {
+                    handlers.add(new EventHandler(listener, m));
+                }
+                handlersInMethod.put(e.getKey(), handlers);
+            }
+        }
+
+        return handlersInMethod;
+    }
+
+    private AnnotatedHandlerFinder() {
+        // No instances.
+    }
 
 }

--- a/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
+++ b/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
@@ -36,22 +36,22 @@ import java.util.concurrent.ConcurrentMap;
 final class AnnotatedHandlerFinder {
 
   /** Cache event bus producer methods for each class. */
-  private static final ConcurrentMap<Class<?>, Map<Class<?>, Method>> PRODUCERS_CACHE =
-    new ConcurrentHashMap<Class<?>, Map<Class<?>, Method>>();
+  private static final ConcurrentMap<Class<?>, Map<String, Method>> PRODUCERS_CACHE =
+          new ConcurrentHashMap<>();
 
   /** Cache event bus subscriber methods for each class. */
-  private static final ConcurrentMap<Class<?>, Map<Class<?>, Set<Method>>> SUBSCRIBERS_CACHE =
-    new ConcurrentHashMap<Class<?>, Map<Class<?>, Set<Method>>>();
+  private static final ConcurrentMap<Class<?>, Map<String, Set<Method>>> SUBSCRIBERS_CACHE =
+          new ConcurrentHashMap<>();
 
   private static void loadAnnotatedProducerMethods(Class<?> listenerClass,
-      Map<Class<?>, Method> producerMethods) {
-    Map<Class<?>, Set<Method>> subscriberMethods = new HashMap<Class<?>, Set<Method>>();
+                                                   Map<String, Method> producerMethods) {
+    Map<String, Set<Method>> subscriberMethods = new HashMap<>();
     loadAnnotatedMethods(listenerClass, producerMethods, subscriberMethods);
   }
 
   private static void loadAnnotatedSubscriberMethods(Class<?> listenerClass,
-      Map<Class<?>, Set<Method>> subscriberMethods) {
-    Map<Class<?>, Method> producerMethods = new HashMap<Class<?>, Method>();
+                                                     Map<String, Set<Method>> subscriberMethods) {
+    Map<String, Method> producerMethods = new HashMap<>();
     loadAnnotatedMethods(listenerClass, producerMethods, subscriberMethods);
   }
 
@@ -59,8 +59,7 @@ final class AnnotatedHandlerFinder {
    * Load all methods annotated with {@link Produce} or {@link Subscribe} into their respective caches for the
    * specified class.
    */
-  private static void loadAnnotatedMethods(Class<?> listenerClass,
-      Map<Class<?>, Method> producerMethods, Map<Class<?>, Set<Method>> subscriberMethods) {
+  private static void loadAnnotatedMethods(Class<?> listenerClass, Map<String, Method> producerMethods, Map<String, Set<Method>> subscriberMethods) {
     for (Method method : listenerClass.getDeclaredMethods()) {
       // The compiler sometimes creates synthetic bridge methods as part of the
       // type erasure process. As of JDK8 these methods now include the same
@@ -87,10 +86,16 @@ final class AnnotatedHandlerFinder {
               + " but is not 'public'.");
         }
 
-        Set<Method> methods = subscriberMethods.get(eventType);
+        Subscribe annotation = method.getAnnotation(Subscribe.class);
+        String keyName = annotation.event();
+        if ("".equals(keyName)) {
+          keyName = eventType.getName();
+        }
+
+        Set<Method> methods = subscriberMethods.get(keyName);
         if (methods == null) {
           methods = new HashSet<Method>();
-          subscriberMethods.put(eventType, methods);
+          subscriberMethods.put(keyName, methods);
         }
         methods.add(method);
       } else if (method.isAnnotationPresent(Produce.class)) {
@@ -121,7 +126,13 @@ final class AnnotatedHandlerFinder {
         if (producerMethods.containsKey(eventType)) {
           throw new IllegalArgumentException("Producer for type " + eventType + " has already been registered.");
         }
-        producerMethods.put(eventType, method);
+
+        Produce annotation = method.getAnnotation(Produce.class);
+        String keyName = annotation.event();
+        if ("".equals(keyName)) {
+          keyName = eventType.getName();
+        }
+        producerMethods.put(keyName, method);
       }
     }
 
@@ -130,17 +141,17 @@ final class AnnotatedHandlerFinder {
   }
 
   /** This implementation finds all methods marked with a {@link Produce} annotation. */
-  static Map<Class<?>, EventProducer> findAllProducers(Object listener) {
+  static Map<String, EventProducer> findAllProducers(Object listener) {
     final Class<?> listenerClass = listener.getClass();
-    Map<Class<?>, EventProducer> handlersInMethod = new HashMap<Class<?>, EventProducer>();
+    Map<String, EventProducer> handlersInMethod = new HashMap<>();
 
-    Map<Class<?>, Method> methods = PRODUCERS_CACHE.get(listenerClass);
+    Map<String, Method> methods = PRODUCERS_CACHE.get(listenerClass);
     if (null == methods) {
-      methods = new HashMap<Class<?>, Method>();
+      methods = new HashMap<>();
       loadAnnotatedProducerMethods(listenerClass, methods);
     }
     if (!methods.isEmpty()) {
-      for (Map.Entry<Class<?>, Method> e : methods.entrySet()) {
+      for (Map.Entry<String, Method> e : methods.entrySet()) {
         EventProducer producer = new EventProducer(listener, e.getValue());
         handlersInMethod.put(e.getKey(), producer);
       }
@@ -150,17 +161,17 @@ final class AnnotatedHandlerFinder {
   }
 
   /** This implementation finds all methods marked with a {@link Subscribe} annotation. */
-  static Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener) {
+  static Map<String, Set<EventHandler>> findAllSubscribers(Object listener) {
     Class<?> listenerClass = listener.getClass();
-    Map<Class<?>, Set<EventHandler>> handlersInMethod = new HashMap<Class<?>, Set<EventHandler>>();
+    Map<String, Set<EventHandler>> handlersInMethod = new HashMap<>();
 
-    Map<Class<?>, Set<Method>> methods = SUBSCRIBERS_CACHE.get(listenerClass);
+    Map<String, Set<Method>> methods = SUBSCRIBERS_CACHE.get(listenerClass);
     if (null == methods) {
-      methods = new HashMap<Class<?>, Set<Method>>();
+      methods = new HashMap<>();
       loadAnnotatedSubscriberMethods(listenerClass, methods);
     }
     if (!methods.isEmpty()) {
-      for (Map.Entry<Class<?>, Set<Method>> e : methods.entrySet()) {
+      for (Map.Entry<String, Set<Method>> e : methods.entrySet()) {
         Set<EventHandler> handlers = new HashSet<EventHandler>();
         for (Method m : e.getValue()) {
           handlers.add(new EventHandler(listener, m));

--- a/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
+++ b/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
@@ -87,11 +87,11 @@ final class AnnotatedHandlerFinder {
                 }
 
                 Class<?> eventType = parameterTypes[0];
-                if (eventType.isInterface())
-                {
-                  throw new IllegalArgumentException("Method " + method + " has @Subscribe annotation on " + eventType
-                          + " which is an interface.  Subscription must be on a concrete class type.");
-                }
+//                if (eventType.isInterface())
+//                {
+//                  throw new IllegalArgumentException("Method " + method + " has @Subscribe annotation on " + eventType
+//                          + " which is an interface.  Subscription must be on a concrete class type.");
+//                }
 
                 if ((method.getModifiers() & Modifier.PUBLIC) == 0)
                 {

--- a/otto/src/main/java/com/squareup/otto/HandlerFinder.java
+++ b/otto/src/main/java/com/squareup/otto/HandlerFinder.java
@@ -22,19 +22,19 @@ import java.util.Set;
 /** Finds producer and subscriber methods. */
 interface HandlerFinder {
 
-  Map<Class<?>, EventProducer> findAllProducers(Object listener);
+  Map<String, EventProducer> findAllProducers(Object listener);
 
-  Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener);
+  Map<String, Set<EventHandler>> findAllSubscribers(Object listener);
 
 
   HandlerFinder ANNOTATED = new HandlerFinder() {
     @Override
-    public Map<Class<?>, EventProducer> findAllProducers(Object listener) {
+    public Map<String, EventProducer> findAllProducers(Object listener) {
       return AnnotatedHandlerFinder.findAllProducers(listener);
     }
 
     @Override
-    public Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener) {
+    public Map<String, Set<EventHandler>> findAllSubscribers(Object listener) {
       return AnnotatedHandlerFinder.findAllSubscribers(listener);
     }
   };

--- a/otto/src/main/java/com/squareup/otto/InheritSubscribers.java
+++ b/otto/src/main/java/com/squareup/otto/InheritSubscribers.java
@@ -1,0 +1,14 @@
+package com.squareup.otto;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Created by yunarta on 6/8/15.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface InheritSubscribers {
+}

--- a/otto/src/main/java/com/squareup/otto/Produce.java
+++ b/otto/src/main/java/com/squareup/otto/Produce.java
@@ -32,4 +32,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Produce {
+
+    /**
+     * Default event name.
+     * <p>
+     * If its empty, the class type will be used instead.
+     */
+    String event() default "";
 }

--- a/otto/src/main/java/com/squareup/otto/Subscribe.java
+++ b/otto/src/main/java/com/squareup/otto/Subscribe.java
@@ -34,4 +34,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Subscribe {
+
+    /**
+     * Default event name.
+     * <p>
+     * If its empty, the class type will be used instead.
+     */
+    String event() default "";
 }

--- a/otto/src/main/java/com/squareup/otto/ThreadEnforcer.java
+++ b/otto/src/main/java/com/squareup/otto/ThreadEnforcer.java
@@ -16,7 +16,7 @@
 
 package com.squareup.otto;
 
-import android.os.Looper;
+import java.lang.Thread;
 
 /**
  * Enforces a thread confinement policy for methods on a particular event bus.
@@ -42,9 +42,13 @@ public interface ThreadEnforcer {
 
   /** A {@link ThreadEnforcer} that confines {@link Bus} methods to the main thread. */
   ThreadEnforcer MAIN = new ThreadEnforcer() {
+
+    long id = Thread.currentThread().getId();
+
     @Override public void enforce(Bus bus) {
-      if (Looper.myLooper() != Looper.getMainLooper()) {
-        throw new IllegalStateException("Event bus " + bus + " accessed from non-main thread " + Looper.myLooper());
+      Thread thread = Thread.currentThread(); if (id != thread.getId()) {
+        String name = "Looper (" + thread.getName() + ", tid " + thread.getId() + ") {" + Integer.toHexString(System.identityHashCode(thread)) + "}";
+        throw new IllegalStateException("Event bus " + bus + " accessed from non-main thread " + name);
       }
     }
   };


### PR DESCRIPTION
Modification now allow Bus to be used on different thread message queue model, such as different Looper from main, but still enforcing that event can only originated from the same Looper thread.

This will improve usage for service running background thread, as well it will make it easy to compile the project without adding Android dependencies. 

This would not hinder usage from entry level Android dev as they would likely to use it on Android main thread, within the UI level. But allow seasonal Android user to build up bigger scale usage using this library