### PR TITLE
Allow for explicit class targeting when registering producer/subscriber methods

### DIFF
--- a/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
+++ b/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
@@ -61,18 +61,6 @@ final class AnnotatedHandlerFinder {
    */
   private static void loadAnnotatedMethods(Class<?> listenerClass,
       Map<Class<?>, Method> producerMethods, Map<Class<?>, Set<Method>> subscriberMethods) {
-    loadAnnotatedMethodsForListenerClass(listenerClass, producerMethods, subscriberMethods);
-
-    PRODUCERS_CACHE.put(listenerClass, producerMethods);
-    SUBSCRIBERS_CACHE.put(listenerClass, subscriberMethods);
-  }
-
-  /**
-   * Load all methods annotated with {@link Produce} or {@link Subscribe} into their respective caches for the
-   * specified class.
-   */
-  private static void loadAnnotatedMethodsForListenerClass(Class<?> listenerClass, Map<Class<?>, Method> producerMethods,
-      Map<Class<?>, Set<Method>> subscriberMethods) {
     for (Method method : listenerClass.getDeclaredMethods()) {
       // The compiler sometimes creates synthetic bridge methods as part of the
       // type erasure process. As of JDK8 these methods now include the same
@@ -136,6 +124,9 @@ final class AnnotatedHandlerFinder {
         producerMethods.put(eventType, method);
       }
     }
+
+    PRODUCERS_CACHE.put(listenerClass, producerMethods);
+    SUBSCRIBERS_CACHE.put(listenerClass, subscriberMethods);
   }
 
   /** This implementation finds all methods marked with a {@link Produce} annotation. */

--- a/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
+++ b/otto/src/main/java/com/squareup/otto/AnnotatedHandlerFinder.java
@@ -49,22 +49,10 @@ final class AnnotatedHandlerFinder {
     loadAnnotatedMethods(listenerClass, producerMethods, subscriberMethods);
   }
 
-  private static void loadAnnotatedProducerMethods(Class<?> fakeListenerClass,
-      Class<?> listenerClass, Map<Class<?>, Method> producerMethods) {
-    Map<Class<?>, Set<Method>> subscriberMethods = new HashMap<Class<?>, Set<Method>>();
-    loadAnnotatedMethods(fakeListenerClass, listenerClass, producerMethods, subscriberMethods);
-  }
-
   private static void loadAnnotatedSubscriberMethods(Class<?> listenerClass,
       Map<Class<?>, Set<Method>> subscriberMethods) {
     Map<Class<?>, Method> producerMethods = new HashMap<Class<?>, Method>();
     loadAnnotatedMethods(listenerClass, producerMethods, subscriberMethods);
-  }
-
-  private static void loadAnnotatedSubscriberMethods(Class<?> fakeListenerClass,
-      Class<?> listenerClass, Map<Class<?>, Set<Method>> subscriberMethods) {
-    Map<Class<?>, Method> producerMethods = new HashMap<Class<?>, Method>();
-    loadAnnotatedMethods(fakeListenerClass, listenerClass, producerMethods, subscriberMethods);
   }
 
   /**
@@ -77,18 +65,6 @@ final class AnnotatedHandlerFinder {
 
     PRODUCERS_CACHE.put(listenerClass, producerMethods);
     SUBSCRIBERS_CACHE.put(listenerClass, subscriberMethods);
-  }
-
-  /**
-   * Load all methods annotated with {@link Produce} or {@link Subscribe} into their respective caches for the
-   * specified class.
-   */
-  private static void loadAnnotatedMethods(Class<?> fakeListenerClass, Class<?> listenerClass,
-      Map<Class<?>, Method> producerMethods, Map<Class<?>, Set<Method>> subscriberMethods) {
-    loadAnnotatedMethodsForListenerClass(listenerClass, producerMethods, subscriberMethods);
-
-    PRODUCERS_CACHE.put(fakeListenerClass, producerMethods);
-    SUBSCRIBERS_CACHE.put(fakeListenerClass, subscriberMethods);
   }
 
   /**
@@ -163,8 +139,7 @@ final class AnnotatedHandlerFinder {
   }
 
   /** This implementation finds all methods marked with a {@link Produce} annotation. */
-  static Map<Class<?>, EventProducer> findAllProducers(Object listener) {
-    final Class<?> listenerClass = listener.getClass();
+  static Map<Class<?>, EventProducer> findAllProducers(Object listener, Class<?> listenerClass) {
     Map<Class<?>, EventProducer> handlersInMethod = new HashMap<Class<?>, EventProducer>();
 
     Map<Class<?>, Method> methods = PRODUCERS_CACHE.get(listenerClass);
@@ -182,57 +157,14 @@ final class AnnotatedHandlerFinder {
     return handlersInMethod;
   }
 
-  /** This implementation finds all methods marked with a {@link Produce} annotation. */
-  static Map<Class<?>, EventProducer> findAllProducers(Object listener, Class<?> listenerClass) {
-    Class<?> fakeListenerClass = listener.getClass();
-    Map<Class<?>, EventProducer> handlersInMethod = new HashMap<Class<?>, EventProducer>();
-
-    Map<Class<?>, Method> methods = PRODUCERS_CACHE.get(fakeListenerClass);
-    if (null == methods) {
-      methods = new HashMap<Class<?>, Method>();
-      loadAnnotatedProducerMethods(fakeListenerClass, listenerClass, methods);
-    }
-    if (!methods.isEmpty()) {
-      for (Map.Entry<Class<?>, Method> e : methods.entrySet()) {
-        EventProducer producer = new EventProducer(listener, e.getValue());
-        handlersInMethod.put(e.getKey(), producer);
-      }
-    }
-
-    return handlersInMethod;
-  }
-
   /** This implementation finds all methods marked with a {@link Subscribe} annotation. */
-  static Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener) {
-    Class<?> listenerClass = listener.getClass();
+  static Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener, Class<?> listenerClass) {
     Map<Class<?>, Set<EventHandler>> handlersInMethod = new HashMap<Class<?>, Set<EventHandler>>();
 
     Map<Class<?>, Set<Method>> methods = SUBSCRIBERS_CACHE.get(listenerClass);
     if (null == methods) {
       methods = new HashMap<Class<?>, Set<Method>>();
       loadAnnotatedSubscriberMethods(listenerClass, methods);
-    }
-    if (!methods.isEmpty()) {
-      for (Map.Entry<Class<?>, Set<Method>> e : methods.entrySet()) {
-        Set<EventHandler> handlers = new HashSet<EventHandler>();
-        for (Method m : e.getValue()) {
-          handlers.add(new EventHandler(listener, m));
-        }
-        handlersInMethod.put(e.getKey(), handlers);
-      }
-    }
-
-    return handlersInMethod;
-  }
-
-  static Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener, Class<?> listenerClass) {
-    Class<?> fakeListenerClass = listener.getClass();
-    Map<Class<?>, Set<EventHandler>> handlersInMethod = new HashMap<Class<?>, Set<EventHandler>>();
-
-    Map<Class<?>, Set<Method>> methods = SUBSCRIBERS_CACHE.get(fakeListenerClass);
-    if (null == methods) {
-      methods = new HashMap<Class<?>, Set<Method>>();
-      loadAnnotatedSubscriberMethods(fakeListenerClass, listenerClass, methods);
     }
     if (!methods.isEmpty()) {
       for (Map.Entry<Class<?>, Set<Method>> e : methods.entrySet()) {

--- a/otto/src/main/java/com/squareup/otto/Bus.java
+++ b/otto/src/main/java/com/squareup/otto/Bus.java
@@ -179,7 +179,7 @@ public class Bus {
    * the value from the result of calling the producer.
    *
    * @param object object whose producer and handler methods should be registered.
-   * @throws NullPointerException if {@code object} or {@code listenerClass} is null.
+   * @throws NullPointerException if {@code object} is null.
    */
   public void register(Object object) {
     if (object == null) {
@@ -201,7 +201,7 @@ public class Bus {
    *               instanceof {@code listenerClass} or {@code listenerClass} must be assignable from the class of
    *               {@code object}; ie a parent class of {@code object}.
    * @param listenerClass class whose producer and handler methods should be registered.
-   * @throws NullPointerException if the object is null.
+   * @throws NullPointerException if {@code object} or {@code listenerClass} is null.
    */
   public void register(Object object, Class<?> listenerClass) {
     if (object == null) {
@@ -283,7 +283,7 @@ public class Bus {
    *
    * @param object object whose producer and handler methods should be unregistered.
    * @throws IllegalArgumentException if the object was not previously registered.
-   * @throws NullPointerException if the object is null.
+   * @throws NullPointerException if {@code object} is null.
    */
   public void unregister(Object object) {
     if (object == null) {

--- a/otto/src/main/java/com/squareup/otto/Bus.java
+++ b/otto/src/main/java/com/squareup/otto/Bus.java
@@ -179,7 +179,7 @@ public class Bus {
    * the value from the result of calling the producer.
    *
    * @param object object whose producer and handler methods should be registered.
-   * @throws NullPointerException if the object is null.
+   * @throws NullPointerException if {@code object} or {@code listenerClass} is null.
    */
   public void register(Object object) {
     if (object == null) {
@@ -300,7 +300,7 @@ public class Bus {
    *               {@code object}; ie a parent class of {@code object}.
    * @param listenerClass class whose producer and handler methods should be unregistered.
    * @throws IllegalArgumentException if the object was not previously registered.
-   * @throws NullPointerException if the object is null.
+   * @throws NullPointerException if {@code object} or {@code listenerClass} is null.
    */
   public void unregister(Object object, Class<?> listenerClass) {
     if (object == null) {

--- a/otto/src/main/java/com/squareup/otto/Bus.java
+++ b/otto/src/main/java/com/squareup/otto/Bus.java
@@ -203,12 +203,7 @@ public class Bus {
     }
     enforcer.enforce(this);
 
-    register(handlerFinder.findAllProducers(object, listenerClass),
-        handlerFinder.findAllSubscribers(object, listenerClass));
-  }
-
-  private void register(Map<Class<?>, EventProducer> foundProducers,
-      Map<Class<?>, Set<EventHandler>> foundHandlersMap) {
+    Map<Class<?>, EventProducer> foundProducers = handlerFinder.findAllProducers(object, listenerClass);
     for (Class<?> type : foundProducers.keySet()) {
 
       final EventProducer producer = foundProducers.get(type);
@@ -227,6 +222,7 @@ public class Bus {
       }
     }
 
+    Map<Class<?>, Set<EventHandler>> foundHandlersMap = handlerFinder.findAllSubscribers(object, listenerClass);
     for (Class<?> type : foundHandlersMap.keySet()) {
       Set<EventHandler> handlers = handlersByType.get(type);
       if (handlers == null) {
@@ -297,12 +293,7 @@ public class Bus {
     }
     enforcer.enforce(this);
 
-    unregister(object, handlerFinder.findAllProducers(object, listenerClass),
-        handlerFinder.findAllSubscribers(object, listenerClass));
-  }
-
-  private void unregister(Object object, Map<Class<?>, EventProducer> producersInListener,
-      Map<Class<?>, Set<EventHandler>> handlersInListener) {
+    Map<Class<?>, EventProducer> producersInListener = handlerFinder.findAllProducers(object, listenerClass);
     for (Map.Entry<Class<?>, EventProducer> entry : producersInListener.entrySet()) {
       final Class<?> key = entry.getKey();
       EventProducer producer = getProducerForEventType(key);
@@ -316,6 +307,7 @@ public class Bus {
       producersByType.remove(key).invalidate();
     }
 
+    Map<Class<?>, Set<EventHandler>> handlersInListener = handlerFinder.findAllSubscribers(object, listenerClass);
     for (Map.Entry<Class<?>, Set<EventHandler>> entry : handlersInListener.entrySet()) {
       Set<EventHandler> currentHandlers = getHandlersForEventType(entry.getKey());
       Collection<EventHandler> eventMethodsInListener = entry.getValue();

--- a/otto/src/main/java/com/squareup/otto/Bus.java
+++ b/otto/src/main/java/com/squareup/otto/Bus.java
@@ -178,10 +178,13 @@ public class Bus {
    * If any producers are registering for types which already have subscribers, each subscriber will be called with
    * the value from the result of calling the producer.
    *
-   * @param object object whose handler methods should be registered.
+   * @param object object whose producer and handler methods should be registered.
    * @throws NullPointerException if the object is null.
    */
   public void register(Object object) {
+    if (object == null) {
+      throw new NullPointerException("Object to register must not be null.");
+    }
     register(object, object.getClass());
   }
 
@@ -194,12 +197,18 @@ public class Bus {
    * If any producers are registering for types which already have subscribers, each subscriber will be called with
    * the value from the result of calling the producer.
    *
-   * @param object object whose handler methods should be registered.
+   * @param object object used to trigger registered producer and handler methods. {@code object} must either be an
+   *               instanceof {@code listenerClass} or {@code listenerClass} must be assignable from the class of
+   *               {@code object}; ie a parent class of {@code object}.
+   * @param listenerClass class whose producer and handler methods should be registered.
    * @throws NullPointerException if the object is null.
    */
   public void register(Object object, Class<?> listenerClass) {
     if (object == null) {
-      throw new NullPointerException("Object to register must not be null.");
+      throw new NullPointerException("Object to trigger register methods not be null.");
+    }
+    if (listenerClass == null) {
+      throw new NullPointerException("Class to register must not be null.");
     }
     enforcer.enforce(this);
 
@@ -277,19 +286,28 @@ public class Bus {
    * @throws NullPointerException if the object is null.
    */
   public void unregister(Object object) {
+    if (object == null) {
+      throw new NullPointerException("Object to unregister must not be null.");
+    }
     unregister(object, object.getClass());
   }
 
   /**
    * Unregisters all producer and handler methods on a registered {@code object}.
    *
-   * @param object object whose producer and handler methods should be unregistered.
+   * @param object object used to trigger registered producer and handler methods. {@code object} must either be an
+   *               instanceof {@code listenerClass} or {@code listenerClass} must be assignable from the class of
+   *               {@code object}; ie a parent class of {@code object}.
+   * @param listenerClass class whose producer and handler methods should be unregistered.
    * @throws IllegalArgumentException if the object was not previously registered.
    * @throws NullPointerException if the object is null.
    */
   public void unregister(Object object, Class<?> listenerClass) {
     if (object == null) {
-      throw new NullPointerException("Object to unregister must not be null.");
+      throw new NullPointerException("Object to trigger register methods not be null.");
+    }
+    if (listenerClass == null) {
+      throw new NullPointerException("Class to unregister must not be null.");
     }
     enforcer.enforce(this);
 
@@ -301,7 +319,7 @@ public class Bus {
 
       if (value == null || !value.equals(producer)) {
         throw new IllegalArgumentException(
-            "Missing event producer for an annotated method. Is " + object.getClass()
+            "Missing event producer for an annotated method. Is " + listenerClass
                 + " registered?");
       }
       producersByType.remove(key).invalidate();
@@ -314,7 +332,7 @@ public class Bus {
 
       if (currentHandlers == null || !currentHandlers.containsAll(eventMethodsInListener)) {
         throw new IllegalArgumentException(
-            "Missing event handler for an annotated method. Is " + object.getClass()
+            "Missing event handler for an annotated method. Is " + listenerClass
                 + " registered?");
       }
 

--- a/otto/src/main/java/com/squareup/otto/Bus.java
+++ b/otto/src/main/java/com/squareup/otto/Bus.java
@@ -182,12 +182,7 @@ public class Bus {
    * @throws NullPointerException if the object is null.
    */
   public void register(Object object) {
-    if (object == null) {
-      throw new NullPointerException("Object to register must not be null.");
-    }
-    enforcer.enforce(this);
-
-    register(handlerFinder.findAllProducers(object), handlerFinder.findAllSubscribers(object));
+    register(object, object.getClass());
   }
 
   /**
@@ -286,12 +281,7 @@ public class Bus {
    * @throws NullPointerException if the object is null.
    */
   public void unregister(Object object) {
-    if (object == null) {
-      throw new NullPointerException("Object to unregister must not be null.");
-    }
-    enforcer.enforce(this);
-
-    unregister(object, handlerFinder.findAllProducers(object), handlerFinder.findAllSubscribers(object));
+    unregister(object, object.getClass());
   }
 
   /**

--- a/otto/src/main/java/com/squareup/otto/HandlerFinder.java
+++ b/otto/src/main/java/com/squareup/otto/HandlerFinder.java
@@ -24,18 +24,32 @@ interface HandlerFinder {
 
   Map<Class<?>, EventProducer> findAllProducers(Object listener);
 
+  Map<Class<?>, EventProducer> findAllProducers(Object listener, Class<?> targetClass);
+
   Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener);
 
+  Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener, Class<?> targetClass);
 
   HandlerFinder ANNOTATED = new HandlerFinder() {
+
     @Override
     public Map<Class<?>, EventProducer> findAllProducers(Object listener) {
       return AnnotatedHandlerFinder.findAllProducers(listener);
     }
 
     @Override
+    public Map<Class<?>, EventProducer> findAllProducers(Object listener, Class<?> targetClass) {
+      return AnnotatedHandlerFinder.findAllProducers(listener, targetClass);
+    }
+
+    @Override
     public Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener) {
       return AnnotatedHandlerFinder.findAllSubscribers(listener);
+    }
+
+    @Override
+    public Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener, Class<?> targetClass) {
+      return AnnotatedHandlerFinder.findAllSubscribers(listener, targetClass);
     }
   };
 }

--- a/otto/src/main/java/com/squareup/otto/HandlerFinder.java
+++ b/otto/src/main/java/com/squareup/otto/HandlerFinder.java
@@ -22,29 +22,15 @@ import java.util.Set;
 /** Finds producer and subscriber methods. */
 interface HandlerFinder {
 
-  Map<Class<?>, EventProducer> findAllProducers(Object listener);
-
   Map<Class<?>, EventProducer> findAllProducers(Object listener, Class<?> targetClass);
-
-  Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener);
 
   Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener, Class<?> targetClass);
 
   HandlerFinder ANNOTATED = new HandlerFinder() {
 
     @Override
-    public Map<Class<?>, EventProducer> findAllProducers(Object listener) {
-      return AnnotatedHandlerFinder.findAllProducers(listener);
-    }
-
-    @Override
     public Map<Class<?>, EventProducer> findAllProducers(Object listener, Class<?> targetClass) {
       return AnnotatedHandlerFinder.findAllProducers(listener, targetClass);
-    }
-
-    @Override
-    public Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener) {
-      return AnnotatedHandlerFinder.findAllSubscribers(listener);
     }
 
     @Override

--- a/otto/src/test/java/com/squareup/otto/UnregisteringHandlerTest.java
+++ b/otto/src/test/java/com/squareup/otto/UnregisteringHandlerTest.java
@@ -98,13 +98,13 @@ public class UnregisteringHandlerTest {
     };
 
     @Override
-    public Map<Class<?>, EventProducer> findAllProducers(Object listener) {
-      return HandlerFinder.ANNOTATED.findAllProducers(listener);
+    public Map<Class<?>, EventProducer> findAllProducers(Object listener, Class<?> targetClass) {
+      return HandlerFinder.ANNOTATED.findAllProducers(listener, targetClass);
     }
 
     @Override
-    public Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener) {
-      Map<Class<?>, Set<EventHandler>> found = HandlerFinder.ANNOTATED.findAllSubscribers(listener);
+    public Map<Class<?>, Set<EventHandler>> findAllSubscribers(Object listener, Class<?> targetClass) {
+      Map<Class<?>, Set<EventHandler>> found = HandlerFinder.ANNOTATED.findAllSubscribers(listener, targetClass);
       Map<Class<?>, Set<EventHandler>> sorted = new HashMap<Class<?>, Set<EventHandler>>();
       for (Map.Entry<Class<?>, Set<EventHandler>> entry : found.entrySet()) {
         SortedSet<EventHandler> handlers = new TreeSet<EventHandler>(handlerComparator);


### PR DESCRIPTION
When registering/unregistering within parent classes consumers now have the ability to point to the parent and use producer/subscriber annotated methods within. This uses the child class instance to reflectively trigger the parent class method.