### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can also depend on the .jar through Maven:
 ```
 or Gradle:
 ```groovy
-compile 'com.squareup:otto:1.3.8'
+implementation 'com.squareup:otto:1.3.8'
 ```
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.